### PR TITLE
Make References font size consistent for natbib

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -19,7 +19,7 @@
 % derived file acmart.cls, and
 %
 % \fi
-% \CheckSum{3061}
+% \CheckSum{3064}
 %
 %
 %% \CharacterTable
@@ -1146,6 +1146,7 @@ Computing Machinery]
 \if@ACM@natbib
   \RequirePackage{natbib}
   \bibpunct[, ]{[}{]}{;}{a}{}{,}
+  \renewcommand{\bibfont}{\bibliofont}
 \fi
 %    \end{macrocode}
 %


### PR DESCRIPTION
Class `amsart` defines environment `thebibliography` and uses command `\bibliofont` to set the font for the References section; the default definition of `\bibliofont` is `\footnotesize`.

With `natbib=true`, package `natbib` redefines environment `thebibliography` and uses command `\bibfont` to set the font; the default definition of `\bibfont` is `\@empty`.

Renew the `\bibfont` command as `\bibliofont` to make References font size consistent with or without `natbib`.  Formats that need to control the References font size need only renew the `\bibliofont` command to be applied consistently with or without `natbib`.