### PR TITLE
Shorten "Keywords" section title for proceedings

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -2817,8 +2817,12 @@ Computing Machinery]
          \@terms\par}\egroup
    \fi
    \ifx\@keywords\@empty\else\bgroup
-      {\@specialsection{Additional Key
-        Words and Phrases}\@keywords}\par\egroup
+      {\if@ACM@journal
+         \@specialsection{Additional Key Words and Phrases}%
+       \else
+         \@specialsection{Keywords}%
+       \fi
+         \@keywords}\par\egroup
    \fi
   \andify\authors
   \andify\shortauthors


### PR DESCRIPTION
The long section title "Additional Key Words and Phrases" requires two
lines in 2-column proceedings format at larger font sizes.

Also, `sig-alternate.cls`, `sigplanconf.cls`, and `acmsiggraph.cls` use
"Keywords" for the section title.  `sigchi.cls` uses "Author Keywords"
for the section title.