### PR TITLE
Additional natbib support

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1267,7 +1267,7 @@ Computing Machinery]
 %    \end{macrocode}
 %
 % Citations.  We patch \cs{setcitestyle} to allow, e.g.,
-% \cs{setcitestyle}|{sort&compress}| 
+% \cs{setcitestyle}|{sort}| and \cs{setcitestyle}|{nosort}|
 %    \begin{macrocode}
 \if@ACM@natbib
   \RequirePackage{natbib}
@@ -1301,8 +1301,12 @@ Computing Machinery]
      \let\bibstyle=\@citestyle\fi
    \def\@tempb{sort}\ifx\@tempa\@tempb
      \def\NAT@sort{\@ne}\fi
+   \def\@tempb{nosort}\ifx\@tempa\@tempb
+     \def\NAT@sort{\z@}\fi
    \def\@tempb{compress}\ifx\@tempa\@tempb
      \def\NAT@cmprs{\@ne}\fi
+   \def\@tempb{nocompress}\ifx\@tempa\@tempb
+     \def\NAT@cmprs{\@z}\fi
    \def\@tempb{sort&compress}\ifx\@tempa\@tempb
      \def\NAT@sort{\@ne}\def\NAT@cmprs{\@ne}\fi
    \def\@tempb{mcite}\ifx\@tempa\@tempb

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1271,7 +1271,6 @@ Computing Machinery]
 %    \begin{macrocode}
 \if@ACM@natbib
   \RequirePackage{natbib}
-  \bibpunct[, ]{[}{]}{;}{a}{}{,}
   \renewcommand{\bibfont}{\bibliofont}
   \renewcommand\setcitestyle[1]{
   \@for\@tempa:=#1\do
@@ -1337,7 +1336,11 @@ Computing Machinery]
    \fi
   }%
   \NAT@@setcites
- }
+  }
+  \setcitestyle{%
+    open={[},close={]},citesep={;},%
+    authoryear,aysep={},yysep={,},%
+    notesep={, }}
 \fi
 %    \end{macrocode}
 %


### PR DESCRIPTION
* Support `nosort` and `nocompress` in `\setcitestyle`: allows disabling `sort` and `compress` should they be enabled by a format's default.
* Use `\setcitestyle` rather than `\bibpunct` for defaulting: The named arguments of `\setcitestyle` better document the citation style and will make it easier for SIG-level customization.