### PR TITLE
Load package zi4 before package newtxmath

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1022,8 +1022,8 @@ Computing Machinery]
 \documentclass{ltxdoc}
 \usepackage{array,booktabs,amsmath,graphicx,fancyvrb,tabularx}
 \usepackage[tt=false]{libertine}
-\usepackage[libertine]{newtxmath}
 \usepackage[varqu]{zi4}
+\usepackage[libertine]{newtxmath}
 \usepackage[tableposition=top]{caption}
 \usepackage{hypdoc}
 \PageIndex
@@ -1700,8 +1700,8 @@ Computing Machinery]
 % We use Times throughout
 %    \begin{macrocode}
 \usepackage[tt=false]{libertine}
-\usepackage[libertine]{newtxmath}
 \usepackage[varqu]{zi4}
+\usepackage[libertine]{newtxmath}
 %    \end{macrocode}
 %
 % The SIGCHI extended abstracts are sans serif:


### PR DESCRIPTION
When processed, the newtxmath package uses the text fonts loaded for
mathrm, mathit, mathsf, and mathtt.  Process the zi4 package before the
newtxmath package so that Inconsolata is used for both texttt and
mathtt, as Libertine is used for mathrm, mathit, and mathsf.