### PR TITLE
SIGPLAN: revert caption rules

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -868,16 +868,6 @@
 % \item[margintable:] a table on the margin
 % \end{description}
 %
-% \DescribeMacro{\nocaptionrule}%
-% \DescribeMacro{\captionruleoff}%
-% \DescribeMacro{\captionruleon}%
-% SIGPLAN format uses rules between captions and float bodies.  In
-% some cases these rules interfere with the material.  The command
-% \cs{nocaptionrule} before the caption (but inside figure or table)
-% switches the rule off.  The command \cs{captionruleoff} switches off
-% caption rules for all subsequent figures, while the command
-% \cs{captionruleon} switches them on.  In other formats these commands
-% do not make any difference.
 %
 %\subsection{Theorems}
 %\label{sec:ug_theorems}
@@ -1007,7 +997,7 @@
 \ProvidesFile{acmart.dtx}
 %</gobble>
 %<class>\ProvidesClass{acmart}
-[2016/05/14 v1.08 Typesetting articles for Association of
+[2016/05/18 v1.09 Typesetting articles for Association of
 Computing Machinery]
 %    \end{macrocode}
 %
@@ -1031,6 +1021,7 @@ Computing Machinery]
 % acmsiggraph and doi numbers for sigproc.bib}
 % \changes{v1.08}{2016/05/13}{SIGPLAN reformatting by Matthew Fluet}
 % \changes{v1.08}{2016/05/13}{Typos corrected (Tobias Pape)}
+% \changes{v1.09}{2016/05/18}{Revert SIGPLAN caption rules}
 %
 %
 % And the driver code:
@@ -1757,73 +1748,6 @@ Computing Machinery]
 %    \begin{macrocode}
 \RequirePackage{caption, float}
 \captionsetup[table]{position=top}
-%    \end{macrocode}
-% 
-%
-%
-% \begin{macro}{\if@ACM@captionrule}
-% \changes{v1.08}{2016/05/14}{Introduced macro}
-%   Whether to use caption rules in SIGPLAN.  We define it here, so
-%   caption rule commands do not produce errors with other
-%   formats. Fortunately, other formats do not use rules.
-%    \begin{macrocode}
-\newif\if@ACM@captionrule
-\@ACM@captionruletrue
-%    \end{macrocode}
-% \end{macro}
-%
-%
-% \begin{macro}{\nocaptionrule}
-% \changes{v1.08}{2016/05/14}{Introduced macro}
-%   Locally delete caption rule
-%    \begin{macrocode}
-\def\nocaptionrule{\@ACM@captionrulefalse}
-%    \end{macrocode}
-%   
-% \end{macro}
-%
-% \begin{macro}{\captionruleoff}
-% \changes{v1.08}{2016/05/14}{Introduced macro}
-%   Globally switching rules off
-%    \begin{macrocode}
-\def\captionruleoff{\global\@ACM@captionrulefalse}
-%    \end{macrocode}
-%   
-% \end{macro}
-%
-% \begin{macro}{\captionruleon}
-% \changes{v1.08}{2016/05/14}{Introduced macro}
-%   Globally switching rules on
-%    \begin{macrocode}
-\def\captionruleon{\global\@ACM@captionruletrue}
-%    \end{macrocode}
-%   
-% \end{macro}
-%
-% \begin{macro}{@ACM@capfmtWithRuleAbove}
-% \changes{v1.08}{2016/05/14}{Introduced macro}
-%   The SIGPLAN ruled caption for figures
-%    \begin{macrocode}
-\DeclareCaptionFormat{@ACM@capfmtWithRuleAbove}{%
-  \if@ACM@captionrule\hrulefill\par\noindent\fi#1#2#3\par}
-%    \end{macrocode}
-%   
-% \end{macro}
-%
-% \begin{macro}{@ACM@capfmtWithRuleBelow}
-% \changes{v1.08}{2016/05/14}{Introduced macro}
-%   The SIGPLAN ruled caption for tables
-%    \begin{macrocode}
-\DeclareCaptionFormat{@ACM@capfmtWithRuleBelow}{%
-  #1#2#3\if@ACM@captionrule\par\vspace{-.5\baselineskip}%
-  \noindent\hrulefill\fi\par}
-%    \end{macrocode}
-%   
-% \end{macro}
-%
-%
-% And the actual setup
-%    \begin{macrocode}
 \if@ACM@journal
   \captionsetup{labelfont={sf, small},
     textfont={sf, small},  margin=\z@}
@@ -1840,9 +1764,6 @@ Computing Machinery]
   \or % siggraph
     \captionsetup{textfont={it}}
   \or % sigplan
-    \setlength\abovecaptionskip{4\p@}
-    \captionsetup[figure]{format=@ACM@capfmtWithRuleAbove}
-    \captionsetup[table]{format=@ACM@capfmtWithRuleBelow}
     \captionsetup{labelfont={bf},
       textfont={normalfont}, labelsep=period, margin=\z@}
   \or % sigchi

--- a/sample-sigplan.tex
+++ b/sample-sigplan.tex
@@ -139,11 +139,8 @@ ACM SIG Proceedings.
   \label{fig:teaser}
 \end{teaserfigure}
 
-\captionruleoff % Switching off the rule for teaser
 
 \maketitle
-
-\captionruleon % Switching on the rule for other figures and tables
 
 \input{samplebody-conf}
 

--- a/samplebody-conf.tex
+++ b/samplebody-conf.tex
@@ -168,7 +168,6 @@ in the printed output of this document.
 
 \begin{table*}
   \centering
-  \nocaptionrule % SIGPLAN only; does not do anything in other formats
   \caption{Some Typical Commands}
   \label{tab:commands}
   \begin{tabular}{ccl}
@@ -229,7 +228,6 @@ with \textbf{figure*}, not \textbf{figure}!
 \begin{figure*}
 \centering
 \includegraphics{flies}
-\nocaptionrule % SIGPLAN only; does not do anything in other formats
 \caption{A sample black and white graphic
 that needs to span two columns of text.}
 \end{figure*}


### PR DESCRIPTION
I would have dropped the unwanted caption rules from the original pull request, but it was merged before the discussion began.
