### PR TITLE
Documentation: loaded packages

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -129,11 +129,9 @@
 % later, so you probably have them installed.  Just in case here is
 % the list of these packages:
 % \begin{itemize}
-% \item \textsl{algorithm2e}, \url{http://www.ctan.org/pkg/algorithm2e}
 % \item \textsl{amscls}, \url{http://www.ctan.org/pkg/amscls}
 % \item \textsl{amsfonts}, \url{http://www.ctan.org/pkg/amsfonts}
 % \item \textsl{amsmath}, \url{http://www.ctan.org/pkg/amsmath}
-% \item \textsl{booktabs}, \url{http://www.ctan.org/pkg/booktabs}
 % \item \textsl{caption}, \url{http://www.ctan.org/pkg/caption}
 % \item \textsl{comment}, \url{http://www.ctan.org/pkg/comment}
 % \item \textsl{environ}, \url{http://www.ctan.org/pkg/environ}

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -156,7 +156,6 @@
 % \item \textsl{newtx}, \url{http://www.ctan.org/pkg/newtx}
 % \item \textsl{oberdiek}, \url{http://www.ctan.org/pkg/oberdiek}
 % \item \textsl{pdftex-def}, \url{http://www.ctan.org/pkg/pdftex-def}
-% \item \textsl{relsize}, \url{http://www.ctan.org/pkg/relsize}
 % \item \textsl{setspace}, \url{http://www.ctan.org/pkg/setspace}
 % \item \textsl{tools}, \url{http://www.ctan.org/pkg/tools}
 % \item \textsl{totpages}, \url{http://www.ctan.org/pkg/totpages}


### PR DESCRIPTION
The `algorithm2e`, `booktabs`, and `relsize` packages are not loaded by `acmart`.