### PR TITLE
\citestyle and related updates

### DIFF
--- a/README
+++ b/README
@@ -19,3 +19,7 @@ version 1.12    Bug fixes and documentation updates.
 
 version 1.13    Formatting changes: headers, folios etc.
 		Bibliography changes.
+
+version 1.14    Warn about undefined citation styles; move definitions
+                of acmauthoryear and acmnumeric citation styles before
+                use.

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1478,6 +1478,34 @@ Computing Machinery]
 \fi
 %    \end{macrocode}
 %
+% \begin{macro}{\bibstyle@acmauthoryear}
+% \changes{v1.13}{2016/06/06}{Added macro}
+%   The default author-year format:
+%    \begin{macrocode}
+\newcommand{\bibstyle@acmauthoryear}{%
+  \setcitestyle{%
+    authoryear,%
+    open={(},close={)},citesep={;},%
+    aysep={},yysep={,},%
+    notesep={, }}}
+%    \end{macrocode}
+%
+% \end{macro}
+%
+% \begin{macro}{\bibstyle@acmnumeric}
+% \changes{v1.13}{2016/06/06}{Added macro}
+%   The default author-year format:
+%    \begin{macrocode}
+\newcommand{\bibstyle@acmnumeric}{%
+  \setcitestyle{%
+    numbers,sort&compress,%
+    open={[},close={]},citesep={,},%
+    notesep={, }}}
+%    \end{macrocode}
+%
+% \end{macro}
+%
+%
 % Before we call |hyperref|, we redefine \cs{startsection} commands to
 % their \LaTeX\ defaults, since |amsart| ones are too AMS-specific.
 % We need to do this early since we want |hyperref| to have a chance
@@ -1667,33 +1695,6 @@ Computing Machinery]
     {\if@filesw
        \immediate\write\@auxout{\string\bibstyle{#1}}%
      \fi}}
-%    \end{macrocode}
-%   
-% \end{macro}
-%
-% \begin{macro}{\bibstyle@acmauthoryear}
-% \changes{v1.13}{2016/06/06}{Added macro}
-%   The default author-year format:
-%    \begin{macrocode}
-\newcommand{\bibstyle@acmauthoryear}{%
-  \setcitestyle{%
-    authoryear,%
-    open={(},close={)},citesep={;},%
-    aysep={},yysep={,},%
-    notesep={, }}}
-%    \end{macrocode}
-%   
-% \end{macro}
-%
-% \begin{macro}{\bibstyle@acmnumeric}
-% \changes{v1.13}{2016/06/06}{Added macro}
-%   The default author-year format:
-%    \begin{macrocode}
-\newcommand{\bibstyle@acmnumeric}{%
-  \setcitestyle{%
-    numbers,sort&compress,%
-    open={[},close={]},citesep={,},%
-    notesep={, }}}
 %    \end{macrocode}
 %   
 % \end{macro}

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1393,7 +1393,8 @@ Computing Machinery]
 %    \end{macrocode}
 %
 % Citations.  We patch \cs{setcitestyle} to allow, e.g.,
-% \cs{setcitestyle}|{sort}| and \cs{setcitestyle}|{nosort}|
+% \cs{setcitestyle}|{sort}| and \cs{setcitestyle}|{nosort}|.  We patch
+% \cs{citestyle} to warn about undefined citation styles.
 %    \begin{macrocode}
 \if@ACM@natbib
   \RequirePackage{natbib}
@@ -1463,6 +1464,13 @@ Computing Machinery]
   }%
   \NAT@@setcites
   }
+  \renewcommand\citestyle[1]{%
+    \ifcsname bibstyle@#1\endcsname%
+    \csname bibstyle@#1\endcsname\let\bibstyle\@gobble%
+    \else%
+    \@latex@error{Undefined `#1' citestyle}%
+    \fi
+  }%
   \setcitestyle{%
     open={[},close={]},citesep={;},%
     authoryear,aysep={},yysep={,},%

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -973,7 +973,7 @@
 %
 % \DescribeMacro{\citestyle}%
 % If you use |natbib|, you can select one of two predefined sitation
-% styles: the author-year format |acmauthoryear| or the numberic
+% styles: the author-year format |acmauthoryear| or the numeric
 % format |acmnumeric| using the command \cs{sitestyle}, for example,
 % \begin{verbatim}
 % \citestyle{acmnumeric}

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1078,6 +1078,7 @@ Computing Machinery]
 % \changes{v1.11}{2016/05/27}{Customization of ACM theorem styles and
 % proof environment by Matthew Fluet}
 % \changes{v1.12}{2016/05/30}{Documentation updates}
+% \changes{v1.14}{2016/06/09}{\cs{citestyle} updates (Matthew Fluet)}
 %
 %
 % And the driver code:
@@ -1392,6 +1393,7 @@ Computing Machinery]
 \fi
 %    \end{macrocode}
 %
+% \changes{v1.14}{2016/06/09}{Patched \cs{citestyle}}
 % Citations.  We patch \cs{setcitestyle} to allow, e.g.,
 % \cs{setcitestyle}|{sort}| and \cs{setcitestyle}|{nosort}|.  We patch
 % \cs{citestyle} to warn about undefined citation styles.
@@ -1476,6 +1478,8 @@ Computing Machinery]
 %
 % \begin{macro}{\bibstyle@acmauthoryear}
 % \changes{v1.13}{2016/06/06}{Added macro}
+% \changes{v1.14}{2016/06/09}{Moved def of \cs{bibstyle@acmauthoryear}
+%   before use}
 %   The default author-year format:
 %    \begin{macrocode}
 \newcommand{\bibstyle@acmauthoryear}{%
@@ -1490,6 +1494,8 @@ Computing Machinery]
 %
 % \begin{macro}{\bibstyle@acmnumeric}
 % \changes{v1.13}{2016/06/06}{Added macro}
+% \changes{v1.14}{2016/06/09}{Moved def of \cs{bibstyle@numeric}
+%   before use}
 %   The default author-year format:
 %    \begin{macrocode}
 \newcommand{\bibstyle@acmnumeric}{%

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1471,10 +1471,6 @@ Computing Machinery]
     \@latex@error{Undefined `#1' citestyle}%
     \fi
   }%
-  \setcitestyle{%
-    open={[},close={]},citesep={;},%
-    authoryear,aysep={},yysep={,},%
-    notesep={, }}
 \fi
 %    \end{macrocode}
 %


### PR DESCRIPTION
Patched `\citestyle` command to warn about undefined citation styles (because I found myself using `\citestyle{acmnumbers}` rather than `\citestyle{acmnumeric}`).  Noticed that the `\citestyle{acmauthoryear}` was having no effect due to def coming after use.