### PR TITLE
Make robust against uninitialized journal metadata

### DIFF
--- a/README
+++ b/README
@@ -23,3 +23,5 @@ version 1.13    Formatting changes: headers, folios etc.
 version 1.14    Warn about undefined citation styles; move definitions
                 of acmauthoryear and acmnumeric citation styles before
                 use.
+
+version 1.15    Make robust against uninitialized journal metadata.

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -2384,7 +2384,7 @@ Computing Machinery]
 %
 % The defaults:
 %    \begin{macrocode}
-\def\@journalName{}%
+\def\@journalName{ACM Journal}%
 \def\@journalNameShort{\@journalName}%
 \def\@permissionCodeOne{XXXX-XX}%
 \def\@permissionCodeTwo{}%
@@ -2623,12 +2623,15 @@ Computing Machinery]
 %
 %
 % \begin{macro}{\@acmPubDate}
+% \changes{v1.14}{2016/06/15}{Made robust against uninitialized
+% month (Matthew Fluet)}
 %   The publication date
 %    \begin{macrocode}
-\def\@acmPubDate{\ifcase\@acmMonth\or
+\def\@acmPubDate{\def\@tempa{MM}%
+  \ifx\@acmMonth\@tempa MM\else\ifcase\@acmMonth\or
   January\or February\or March\or April\or May\or June\or
   July\or August\or September\or October\or November\or
-  December\fi~\@acmYear}
+  December\fi\fi~\@acmYear}
 %    \end{macrocode}
 %
 % \end{macro}
@@ -4160,9 +4163,17 @@ Computing Machinery]
 % \end{macro}
 %
 % \begin{macro}{\@folioblob}
+% \changes{v1.14}{2016/06/15}{Made robust against uninitialized
+% article number (Matthew Fluet)}
 %   The macro to typeset the folio blob.
 %    \begin{macrocode}
-\def\@folioblob{\@tempcnta=\@acmArticleSeq\relax
+\def\@folioblob{
+  \def\@tempa{AA}
+  \ifx\@acmArticlSeq\@tempa
+     \@tempcnta=\@acmArticleSeq
+  \else
+     \@tempcnta=1
+  \fi
 %    \end{macrocode}
 % First, we calculate \cs{@acmArticleSeq} modulo \cs{@folio@max}
 %    \begin{macrocode}

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1079,6 +1079,8 @@ Computing Machinery]
 % proof environment by Matthew Fluet}
 % \changes{v1.12}{2016/05/30}{Documentation updates}
 % \changes{v1.14}{2016/06/09}{\cs{citestyle} updates (Matthew Fluet)}
+% \changes{v1.15}{2016/06/09}{Make robust against uninitialized
+% journal metadata (Matthew Fluet)}
 %
 %
 % And the driver code:
@@ -1479,7 +1481,7 @@ Computing Machinery]
 % \begin{macro}{\bibstyle@acmauthoryear}
 % \changes{v1.13}{2016/06/06}{Added macro}
 % \changes{v1.14}{2016/06/09}{Moved def of \cs{bibstyle@acmauthoryear}
-%   before use}
+% before use}
 %   The default author-year format:
 %    \begin{macrocode}
 \newcommand{\bibstyle@acmauthoryear}{%
@@ -1495,7 +1497,7 @@ Computing Machinery]
 % \begin{macro}{\bibstyle@acmnumeric}
 % \changes{v1.13}{2016/06/06}{Added macro}
 % \changes{v1.14}{2016/06/09}{Moved def of \cs{bibstyle@numeric}
-%   before use}
+% before use}
 %   The default author-year format:
 %    \begin{macrocode}
 \newcommand{\bibstyle@acmnumeric}{%
@@ -2623,7 +2625,7 @@ Computing Machinery]
 %
 %
 % \begin{macro}{\@acmPubDate}
-% \changes{v1.14}{2016/06/15}{Made robust against uninitialized
+% \changes{v1.15}{2016/06/15}{Made robust against uninitialized
 % month (Matthew Fluet)}
 %   The publication date
 %    \begin{macrocode}
@@ -4163,7 +4165,7 @@ Computing Machinery]
 % \end{macro}
 %
 % \begin{macro}{\@folioblob}
-% \changes{v1.14}{2016/06/15}{Made robust against uninitialized
+% \changes{v1.15}{2016/06/15}{Made robust against uninitialized
 % article number (Matthew Fluet)}
 %   The macro to typeset the folio blob.
 %    \begin{macrocode}


### PR DESCRIPTION
When `\@acmMonth` or `\@acmArticleSeq` are uninitialized by a document using
a journal format, typesetting stops with an uninformative:
```
  ! Missing number, treated as zero.
```

This might happen when an author transitions a conference paper to a
journal submission (or, in the PACM future, when a submission is
transitioned from a traditional conference proceedings format to the
PACM conference proceedings format).