### PR TITLE
Avoid hyperref warnings due to "\to"

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1834,7 +1834,7 @@ Computing Machinery]
 %    \begin{macrocode}
 \let\@footnotemark@nolink\@footnotemark
 \let\@footnotetext@nolink\@footnotetext
-\RequirePackage[bookmarksnumbered]{hyperref}
+\RequirePackage[bookmarksnumbered,unicode]{hyperref}
 \urlstyle{rm}
 \ifcase\ACM@format@nr
 \relax % manuscript
@@ -2145,8 +2145,6 @@ Computing Machinery]
 \RequirePackage[tt=false]{libertine}
 \RequirePackage[varqu]{zi4}
 \RequirePackage[libertine]{newtxmath}
-\else
-\RequirePackage{textcomp}
 \fi
 %    \end{macrocode}
 %
@@ -3177,11 +3175,14 @@ Computing Machinery]
 % \end{macro}
 %
 % \begin{macro}{\ccsdesc@parse}
-%   The parser of the expression |Significance~General~Specific|:
+%   The parser of the expression |Significance~General~Specific| (we need
+%   |textcomp| for |\\textrightarrow|:
 %    \begin{macrocode}
+\RequirePackage{textcomp}
 \def\ccsdesc@parse#1~#2~#3~{%
   \expandafter\ifx\csname CCS@#2\endcsname\relax
-    \expandafter\gdef\csname CCS@#2\endcsname{\textbullet\textbf{#2} $\to$ }%
+    \expandafter\gdef\csname CCS@#2\endcsname{\textbullet\textbf{#2}
+    \textrightarrow }%
   \g@addto@macro{\@concepts}{\csname CCS@#2\endcsname}\fi
   \expandafter\g@addto@macro\expandafter{\csname CCS@#2\endcsname}{%
     \ifnum#1>499\textbf{#3; }\else

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -3181,8 +3181,7 @@ Computing Machinery]
 \RequirePackage{textcomp}
 \def\ccsdesc@parse#1~#2~#3~{%
   \expandafter\ifx\csname CCS@#2\endcsname\relax
-    \expandafter\gdef\csname CCS@#2\endcsname{\textbullet\textbf{#2}
-    \textrightarrow }%
+    \expandafter\gdef\csname CCS@#2\endcsname{\textbullet\textbf{#2} \textrightarrow }%
   \g@addto@macro{\@concepts}{\csname CCS@#2\endcsname}\fi
   \expandafter\g@addto@macro\expandafter{\csname CCS@#2\endcsname}{%
     \ifnum#1>499\textbf{#3; }\else


### PR DESCRIPTION
Fixes #67 by using `\textrightarrow` from `textcomp` (which is now unconditionally included) and adding `unicode` to `hyperref` (which is potentially useful in general).