### PR TITLE
Removed spurious indent in abstract; improved kerning in CCS description list

### DIFF
--- a/README
+++ b/README
@@ -57,4 +57,5 @@ version 1.27    Bug fixes
 
 version 1.28    Bug fixes: natbib=false now behaves correctly.
 
-
+version 1.29	Removed spurious indent at start of abstract;
+		improved kerning in CCS description list.

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -3199,17 +3199,19 @@ Computing Machinery]
 % \begin{macro}{\ccsdesc@parse}
 % \changes{v1.28}{2017/01/04}{Change from \cs{to} to
 % \cs{textrightarrow} (Matteo Riondato)}
+% \changes{v1.29}{2017/01/22}{Add spacing after bullet and around
+% rightarrow; semicolon separators no longer in bold/italic (John Wickerson)}
 %   The parser of the expression |Significance~General~Specific| (we need
 %   |textcomp| for |\\textrightarrow|:
 %    \begin{macrocode}
 \RequirePackage{textcomp}
 \def\ccsdesc@parse#1~#2~#3~{%
   \expandafter\ifx\csname CCS@#2\endcsname\relax
-    \expandafter\gdef\csname CCS@#2\endcsname{\textbullet\textbf{#2} \textrightarrow }%
+    \expandafter\gdef\csname CCS@#2\endcsname{\textbullet\ \textbf{#2} \textrightarrow\ }%
   \g@addto@macro{\@concepts}{\csname CCS@#2\endcsname}\fi
   \expandafter\g@addto@macro\expandafter{\csname CCS@#2\endcsname}{%
-    \ifnum#1>499\textbf{#3; }\else
-    \ifnum#1>299\textit{#3; }\else
+    \ifnum#1>499\textbf{#3}; \else
+    \ifnum#1>299\textit{#3}; \else
     #3; \fi\fi}}
 %    \end{macrocode}
 %
@@ -4323,6 +4325,7 @@ Computing Machinery]
 % \changes{v1.19}{2016/07/28}{Include 'Abstract' in PDF bookmarks
 % (Matthew Fluet)}
 % \changes{v1.20}{2016/08/03}{Deleted spurious space}
+% \changes{v1.29}{2017/01/22}{Removed spurious indentation (John Wickerson)}
 %   Typesetting abstract
 %    \begin{macrocode}
 \def\@mkabstract{\bgroup
@@ -4330,9 +4333,9 @@ Computing Machinery]
   {\if@ACM@journal
        \small\noindent
     \else
+      \phantomsection\addcontentsline{toc}{section}{Abstract}%
       \section*{Abstract}%
     \fi
-   \phantomsection\addcontentsline{toc}{section}{Abstract}%
    \ignorespaces\@abstract\par}%
   \fi\egroup}
 %    \end{macrocode}


### PR DESCRIPTION
# 1. Removed spurious indent at the start of the abstract. 

The problem seemed to be that the `\addcontentsline` was cancelling out the `\noindent`. I moved the `\addcontentsline` inside the if-statement to fix this. Now the `\addcontentsline` is only called when the abstract has its own `\section` heading, which is appropriate. I also moved the `\phantomheading` so that it comes *above* the `\section*` command - this means that the bookmark is positioned slightly more correctly.

## Before picture
<img width="970" alt="screen shot 2017-01-22 at 18 56 48" src="https://cloud.githubusercontent.com/assets/4182011/22184989/9a84ca00-e0d4-11e6-9696-332bb7f8e662.png">

## After picture

<img width="958" alt="screen shot 2017-01-22 at 20 54 07" src="https://cloud.githubusercontent.com/assets/4182011/22185864/05b7de38-e0e5-11e6-9e70-74dba6c5de71.png">

# 2. Improved kerning in CCS description list.

The spacing around the bullets and around the right-arrows does not look good. I added a few `\ ` spaces to address this. Also, the semicolons that separate the CCS categories have bold or italic formatting, which makes them look inconsistent. I set all the semicolons in the default font style to address this.

## Before picture
<img width="952" alt="screen shot 2017-01-22 at 18 58 06" src="https://cloud.githubusercontent.com/assets/4182011/22185021/28585324-e0d5-11e6-9c08-f759b8d4c68a.png">

## After picture
<img width="957" alt="screen shot 2017-01-22 at 20 54 22" src="https://cloud.githubusercontent.com/assets/4182011/22185883/4892c16e-e0e5-11e6-91eb-14dd489e8ca7.png">


