### PR TITLE
Fix a few typos in docs

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -113,7 +113,7 @@
 %
 % Most probably, you already have this package installed in your
 % favorite \TeX\ distribution;  if not, you may want to upgrade.  You
-% may need to upgrade it anyway since the package uses a number
+% may need to upgrade it anyway since the package uses a number of
 % relatively recent packages, especially the ones related to the
 % fonts.
 %
@@ -891,7 +891,7 @@
 % \item The captions for figures must be entered \emph{after} the
 % figure bodies, and for the tables \emph{before} the table bodies.
 % \item ACM uses the standard types for figures and types and adds
-% several new ones.  In total there are follwing types:
+% several new ones.  In total there are the following types:
 % \begin{description}
 % \item[figure, table:] a standard figure or table, taking full text
 % width in one-column formats and one column in two-column formats.

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -75,7 +75,7 @@
 % educational and scientific computing society, which delivers
 % resources that advance computing as a science and a
 % profession\footnote{\url{http://www.acm.org/}}.  It was one of the
-% earily adopters of \TeX\ for its typesetting.
+% early adopters of \TeX\ for its typesetting.
 %
 % It provided several different classes for a number of journal and
 % conference proceedings.  Unfortunately during the years since these


### PR DESCRIPTION
I noticed these typos while reading `acmart.pdf`. Here's a fix.

Having used previous ACM styles: Kudos on this class file (looks cool!) and on making it available on GitHub!

----

Caveat: I haven't tried recompiling the results (I'm afraid I'm not even sure how to do that), but I'd guess it should just work.