### PR TITLE
Handle toc-like commands

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -4787,15 +4787,6 @@ Computing Machinery]
 %\subsection{TOC Lists}
 %\label{sec:tocs}
 %
-% \begin{macro}{\tableofcontents}
-% Several packages, for example the |todonotes| package, expect something like
-% the \LaTeX\ |article| implementation of  \cs{tableofcontents} and related
-% macros. However, the table of contents does not make too much sense for
-% |acmart|, even in a draft setting. Let's disable it.
-%    \begin{macrocode}
-\let\tableofcontents\@undefined\relax
-%    \end{macrocode}
-% \end{macro}
 % \begin{macro}{\@dotsep}
 % Related to the \cs{tableofcontents} are all the horizontal fillers. Base
 % \LaTeX\ defines \cs{@dottedtocline}, which we should not disable. Yet, this

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -4784,6 +4784,28 @@ Computing Machinery]
 %
 % \end{macro}
 %
+%\subsection{TOC Lists}
+%\label{sec:tocs}
+%
+% \begin{macro}{\tableofcontents}
+% Several packages, for example the |todonotes| package, expect something like
+% the \LaTeX\ |article| implementation of  \cs{tableofcontents} and related
+% macros. However, the table of contents does not make too much sense for
+% |acmart|, even in a draft setting. Let's disable it.
+%    \begin{macrocode}
+\let\tableofcontents\@undefined\relax
+%    \end{macrocode}
+% \end{macro}
+% \begin{macro}{\@dotsep}
+% Related to the \cs{tableofcontents} are all the horizontal fillers. Base
+% \LaTeX\ defines \cs{@dottedtocline}, which we should not disable. Yet, this
+% command expects \cs{@dotsep} to be defined, but leaves this to the class
+% implementation. Since |amsart| does not provide this, we copy the standard
+% variant from |article| here.
+%    \begin{macrocode}
+\providecommand*\@dotsep{4.5}
+%    \end{macrocode}
+% \end{macro}
 %
 %\subsection{Theorems}
 %\label{sec:theorems}


### PR DESCRIPTION
- `\tableofcontents` does not work easily, disable it
 - `\@dotsep` is expected by LaTeX kernel, copy from aricle.cls