### PR TITLE
Fix typos and clarify description for `\acmArticleSeq`.

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -636,9 +636,9 @@
 % \end{verbatim}
 %
 % \DescribeMacro{\acmArticleSeq}%
-% The articles in the same issue of a journal have \emph{sequential
-% number}.  It is used to position black blob in same formats.  By
-% default it is the same as article number, but the command
+% The articles in the same issue of a journal have a \emph{sequential
+% number}.  It is used to vertically position the black blob in some
+% formats.  By default it is the same as article number, but the command
 % \cs{acmArticleSeq}\marg{n} can be used to change it:
 % \begin{verbatim}
 % \acmArticle{39}   % The sequence number will be 39 by default


### PR DESCRIPTION
Changes:

    ... have {+a+} sequential number.  It is used to {+vertically+} position
    {+the+} black blob in {+same->some+} formats.