### PR TITLE
Fix typos at the start of the Bibliography section

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1135,7 +1135,7 @@
 %\subsection{Bibliography}
 %\label{sec:ug_bibliography}
 %
-% ACM uses \textsl{natbib} package for formatting of referencing ant
+% ACM uses the \textsl{natbib} package for formatting references and
 % the style \path{ACM-Reference-Format.bst} for Bib\TeX\
 % processing.  You may disable loading of \textsl{natbib} by using the
 % option |natbib=false| in \cs{documentclass}.  However, it is not


### PR DESCRIPTION
Changes:

    ACM uses {+the+} natbib package for formatting
    {+of referencing->references+} {+ant->and+} the style
    ACM-Reference-Format.bst for BibTeX processing.