### PR TITLE
Grammar and formatting in the "Theorems" section of the guide.

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1046,13 +1046,14 @@
 % theorem environments:
 % \begin{description}
 % \item[acmplain:] this is  the style used for
-% |theorem|,
-% |conjecture|,
-% |proposition|,
-% |lemma|,
-% |corollary|, and
-% \item[acmdefinition:] this is the style used for |example| and
-% |definition|.
+%   |theorem|,
+%   |conjecture|,
+%   |proposition|,
+%   |lemma|, and
+%   |corollary|, and
+% \item[acmdefinition:] this is the style used for
+%   |example| and
+%   |definition|.
 % \end{description}
 %
 %


### PR DESCRIPTION
- Inserted "and" between `lemma` and `corollary`.
- `acmdefinition` environments on own lines (for consistency with `acmplain`)
- Indent environments in `acmplain` and `acmdefinition`