### PR TITLE
Remove spurious blank line in documentation section of `acmart.dtx`

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1125,8 +1125,7 @@
 %
 % As for |printonly| and |screenonly| environments,
 % |\begin{acks}| and |\end{acls}| should start the
-% line of their own (no leading or trailing spaces).  
-
+% line of their own (no leading or trailing spaces).
 %
 % \DescribeMacro{\grantsponsor}%
 % \DescribeMacro{\grantnum}%


### PR DESCRIPTION
Remove spurious blank line in documentation section of `acmart.dtx`