### PR TITLE
Remove spurious blank line at end of `\verbatim`.

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1283,9 +1283,8 @@
 %  month =	 nov,
 %  year = 	 "1996",
 % }
-%
 % \end{verbatim}
-% 
+%
 %
 %\subsection{Colors}
 %\label{sec:ug_colors}


### PR DESCRIPTION
Remove spurious blank line at end of `\verbatim`.