### PR TITLE
Several improvements to `acmart.bib`.

### DIFF
--- a/acmart.bib
+++ b/acmart.bib
@@ -1,89 +1,80 @@
-@misc{TeXFAQ,
-  author =        {{UK \TeX{} Users Group}},
-  howpublished =  {\url{http://www.tex.ac.uk}},
-  title =         {{UK} List of {\TeX} Frequently Asked Questions},
-  year =          {2016},
+@Misc{TeXFAQ,
+  title =	 {{UK} List of {\TeX} Frequently Asked Questions},
+  author =	 {{UK \TeX{} Users Group}},
+  year =	 2016,
+  howpublished = {\url{http://www.tex.ac.uk}}
 }
 
 @Manual{Downes04:amsart,
-  title = 	 {The \textsf{amsart}, \textsf{amsproc}, and 
+  title =	 {The \textsf{amsart}, \textsf{amsproc}, and
                   \textsf{amsbook} document~classes},
   author =	 {Michael Downes and Barbara Beeton},
   organization = {American Mathematical Society},
   year =	 2004,
-  month =        {August},
-  note =	 {\url{http://www.ctan.org/pkg/amslatex}}
-}
-
-@Manual{instr-l,
-  title = 	 {Instructions for Preparation of Papers and
-                  Monographs, {AMS\LaTeX}},
-  organization = {American Mathematical Society},
-  month =	 {August},
-  year =	 2004,
+  month =	 aug,
   note =	 {\url{http://www.ctan.org/pkg/amslatex}}
 }
 
 @Manual{Fiorio15,
-  title = 	 {{a}lgorithm2e.sty---package for algorithms},
+  title =	 {{a}lgorithm2e.sty---package for algorithms},
   author =	 {Cristophe Fiorio},
-  month =	 {October},
   year =	 2015,
-  annote =	 {\url{http://www.ctan.org/pkg/algorithm2e}}
+  month =	 oct,
+  note =	 {\url{http://www.ctan.org/pkg/algorithm2e}}
 }
 
 @Manual{Brito09,
-  title = 	 {The algorithms bundle},
+  title =	 {The algorithms bundle},
   author =	 {Rog\'erio Brito},
-  month =	 {August},
   year =	 2009,
-  annote =	 {\url{http://www.ctan.org/pkg/algorithms}}
+  month =	 aug,
+  note =	 {\url{http://www.ctan.org/pkg/algorithms}}
 }
 
-
 @Manual{Heinz15,
-  title = 	 {The Listings Package},
+  title =	 {The Listings Package},
   author =	 {Carsten Heinz and Brooks Moses and Jobst Hoffmann},
-  month =	 {June},
   year =	 2015,
+  month =	 jun,
   note =	 {\url{http://www.ctan.org/pkg/listings}}
 }
 
 @Manual{Fear05,
-  title = 	 {Publication quality tables in {\LaTeX}},
+  title =	 {Publication quality tables in {\LaTeX}},
   author =	 {Simon Fear},
-  month =	 {April},
   year =	 2005,
+  month =	 apr,
   note =	 {\url{http://www.ctan.org/pkg/booktabs}}
 }
 
 @Manual{ACMIdentityStandards,
-  title = 	 {{ACM} Visual Identity Standards},
+  title =	 {{ACM} Visual Identity Standards},
   organization = {Association for Computing Machinery},
-  year =	 2007
+  year =	 2007,
+  note =	 {\url{http://identitystandards.acm.org}}
 }
 
 @Manual{Sommerfeldt13:Subcaption,
-  title = 	 {The subcaption package},
-  author = 	 {Axel Sommerfeldt},
-  month = 	 {April},
-  year = 	 2013,
-  note = 	 {\url{http://www.ctan.org/pkg/subcaption}},
+  title =	 {The subcaption package},
+  author =	 {Axel Sommerfeldt},
+  year =	 2013,
+  month =	 apr,
+  note =	 {\url{http://www.ctan.org/pkg/subcaption}}
 }
 
-
 @Manual{Nomencl,
-  title = 	 {A package to create a nomenclature},
-  author = 	 {Boris Veytsman and Bern Schandl and Lee Netherton
-                  and CV Radhakrishnan},
-  month = 	 {September},
-  note = 	 {\url{http://www.ctan.org/pkg/nomencl}},
-  year = 	 2005}
+  title =	 {A package to create a nomenclature},
+  author =	 {Boris Veytsman and Bern Schandl and Lee Netherton
+                  and C. V. Radhakrishnan},
+  year =	 2005,
+  month =	 sep,
+  note =	 {\url{http://www.ctan.org/pkg/nomencl}}
+}
 
 @Manual{Talbot16:Glossaries,
-  title = 	 {User Manual for glossaries.sty v4.25},
-  author = 	 {Nicola L. C. Talbot},
-  month = 	 {June},
-  year = 	 2016,
-  note = 	 {\url{http://www.ctan.org/pkg/subcaption}}}
-
+  title =	 {User Manual for glossaries.sty v4.25},
+  author =	 {Nicola L. C. Talbot},
+  year =	 2016,
+  month =	 jun,
+  note =	 {\url{http://www.ctan.org/pkg/subcaption}}
+}


### PR DESCRIPTION
Changes of substance:

- Remove entry for `instr-l` as it is not cited in `acmart.dtx`
- Add `url` to entry for `ACMIdentityStandards`
- Change author name from `CV Radhakrishnan` to `C. V. Radhakrishnan`
- Use `note` instead of `annote`.  (In the standard styles, `annote` fields do
  not appear in the generated bibliography.)
- For `month`, use predefined macros.  E.g., instead of `"August"`, use `aug`
  with no quotes or braces around it.  This puts month name formatting under
  the control of the style file and thus ensures consistency.

Changes for formatting consistency:

- Put fields on consistent order
- Capitalize `@Misc`
- No comma after last field
- Closing `}` on own line
- Consistent spacing