### PR TITLE
Consistent formatting for BibTeX documentation

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1216,14 +1216,14 @@
 %
 % The style supports fields \path{doi} and \path{url}, for example,
 % \begin{verbatim}
-%  doi = "10.1145/1188913.1188915",
-%  url = "http://ccrma.stanford.edu/~jos/bayes/bayes.pdf",
+%  doi =          "10.1145/1188913.1188915",
+%  url =          "http://ccrma.stanford.edu/~jos/bayes/bayes.pdf",
 % \end{verbatim}
 % 
 % The style supports arXiv recommended fields \path{eprint} and
 % (optionally) \path{primaryclass}, for example,
 % \begin{verbatim}
-%  eprint      = "960935712",
+%  eprint =       "960935712",
 %  primaryclass = "cs",
 % \end{verbatim}
 % See the examples at \url{http://arxiv.org/hypertex/bibstyles/}.
@@ -1232,11 +1232,11 @@
 % \path{game} for Web pages and games, for example,
 % \begin{verbatim}
 % @online{Thornburg01,
-%  author = "Harry Thornburg",
-%  year =   "2001",
-%  title =  "Introduction to Bayesian Statistics",
-%  url =    "http://ccrma.stanford.edu/~jos/bayes/bayes.html",
-%  month =   mar,
+%  author =       "Harry Thornburg",
+%  year =         "2001",
+%  title =        "Introduction to Bayesian Statistics",
+%  url =          "http://ccrma.stanford.edu/~jos/bayes/bayes.html",
+%  month =        mar,
 %  lastaccessed = "March 2, 2005",
 % }
 % \end{verbatim}
@@ -1249,13 +1249,13 @@
 % entry, setting there \path{howpublished} field, for example,
 % \begin{verbatim}
 % @online{Obama08,
-%  author = "Barack Obama",
-%  year   = "2008",
-%  title  = "A more perfect union",
-%  howpublished  = "Video",
-%  day 	  = "5",
-%  url    = "http://video.google.com/videoplay?docid=6528042696351994555",
-%  month  = mar,
+%  author =       "Barack Obama",
+%  year   =       "2008",
+%  title  =       "A more perfect union",
+%  howpublished = "Video",
+%  day    =       "5",
+%  url    =       "http://video.google.com/videoplay?docid=6528042696351994555",
+%  month  =       mar,
 %  lastaccessed = "March 21, 2008",
 % }
 % \end{verbatim}
@@ -1267,15 +1267,14 @@
 % @Inproceedings{Novak03,
 %  author =       "Dave Novak",
 %  title =        "Solder man",
-%  booktitle =    {ACM SIGGRAPH 2003 Video Review on Animation theater 
-%                  Program},
+%  booktitle =    "ACM SIGGRAPH 2003 Video Review on Animation theater Program",
 %  year =         "2003",
-%  publisher = 	 "ACM Press",
-%  address = 	 "New York, NY",
+%  publisher =    "ACM Press",
+%  address =      "New York, NY",
 %  pages =        "4",
-%  month = 	 "March 21, 2008",
-%  doi = 	 "99.9999/woot07-S422",
-%  howpublished = "Video"
+%  month =        "March 21, 2008",
+%  doi =          "10.9999/woot07-S422",
+%  howpublished = "Video",
 % }
 % \end{verbatim}
 % 
@@ -1283,14 +1282,14 @@
 % \path{periodical} is intended for this:
 % \begin{verbatim}
 % @periodical{JCohen96,
-%  key = 	 "Cohen",
+%  key =          "Cohen",
 %  editor =       "Jacques Cohen",
 %  title =        "Special issue: Digital Libraries",
-%  journal =      CACM,
+%  journal =      "Communications of the {ACM}",
 %  volume =       "39",
-%  number = 	 "11",
-%  month =	 nov,
-%  year = 	 "1996",
+%  number =       "11",
+%  month =        nov,
+%  year =         "1996",
 % }
 % \end{verbatim}
 %


### PR DESCRIPTION
Changes:

- Indented all fields to same column
- Added comma after the last field of one entry
- Changed one field from brace delimiters to double quotes
- Removed call to `CACM` macro.  (It is deprecated.)
- Change example `doi` to have the `10.` prefix that the `.bst` expects

With these changes, I went with whatever style was most common in the
documentation.  I don't have a strong opinion about which style to use.