### PR TITLE
Fix BibTeX sorting

### DIFF
--- a/ACM-Reference-Format.bst
+++ b/ACM-Reference-Format.bst
@@ -3263,6 +3263,8 @@ FUNCTION { presort }
   type$ "book" =
   type$ "inbook" =
   or
+  type$ "periodical" =
+  or
     'author.editor.sort
     { type$ "proceedings" =
         'editor.organization.sort

--- a/ACM-Reference-Format.bst
+++ b/ACM-Reference-Format.bst
@@ -2375,14 +2375,8 @@ FUNCTION { author.editor.key.label }
   if$
 }
 
-FUNCTION { calc.label }
+FUNCTION { calc.basic.label }
 {
-  % Changed - GNP. See also author.organization.sort, editor.organization.sort
-  % Form label for BibTeX entry. The classification of which fields are used
-  % for which type of entry (book, inbook, etc.) are taken from alpha.bst.
-  % The change here from newapa is to also include organization as a
-  % citation label if author or editor is missing.
-
   type$ "book" =
   type$ "inbook" =
   or
@@ -2399,6 +2393,17 @@ FUNCTION { calc.label }
       if$
     }
   if$
+}
+
+FUNCTION { calc.label }
+{
+  % Changed - GNP. See also author.organization.sort, editor.organization.sort
+  % Form label for BibTeX entry. The classification of which fields are used
+  % for which type of entry (book, inbook, etc.) are taken from alpha.bst.
+  % The change here from newapa is to also include organization as a
+  % citation label if author or editor is missing.
+
+  calc.basic.label
 
   author empty.or.unknown  % generate the full label citation information.
     {
@@ -3308,7 +3313,7 @@ FUNCTION { forward.pass }
   last.label
   % OLD:calc.label year field.or.null purify$ #-1 #4 substring$ * % add year
   % NEW:
-  author.key.label year field.or.null purify$ #-1 #4 substring$ * % add year
+  calc.basic.label year field.or.null purify$ #-1 #4 substring$ * % add year
   #1 entry.max$ substring$ =     % are they equal?
      { last.extra.num #1 + 'last.extra.num :=
        last.extra.num int.to.chr$ 'extra.label :=
@@ -3317,7 +3322,7 @@ FUNCTION { forward.pass }
        "" 'extra.label :=
        % OLD: calc.label year field.or.null purify$ #-1 #4 substring$ * % add year
        % NEW:
-       author.key.label year field.or.null purify$ #-1 #4 substring$ * % add year
+       calc.basic.label year field.or.null purify$ #-1 #4 substring$ * % add year
        #1 entry.max$ substring$ 'last.label := % assign to last.label
      }
   if$

--- a/ACM-Reference-Format.bst
+++ b/ACM-Reference-Format.bst
@@ -2324,23 +2324,6 @@ FUNCTION { author.key.label }
   if$
 }
 
-FUNCTION { author.key.organization.label }
-{ % added - gnp. Provide label formatting by organization if author is null.
-  author empty.or.unknown
-    { organization empty.or.unknown
-        { key empty.or.unknown
-            { "no key, author or organization in " cite$ * warning$
-              cite$ #1 #3 substring$ }
-            'key
-          if$
-        }
-        { organization }
-      if$
-    }
-    { author format.lab.names }
-  if$
-}
-
 FUNCTION { editor.key.organization.label }
 { % added - gnp. Provide label formatting by organization if editor is null.
   editor empty.or.unknown
@@ -2375,6 +2358,27 @@ FUNCTION { author.editor.key.label }
   if$
 }
 
+FUNCTION { author.editor.key.organization.label }
+{ % added - gnp. Provide label formatting by organization if author is null.
+  author empty.or.unknown
+    { editor empty.or.unknown
+        { organization empty.or.unknown
+            { key empty.or.unknown
+               { "no key, author, editor or organization in " cite$ * warning$
+                 cite$ #1 #3 substring$ }
+               'key
+              if$
+            }
+            { organization }
+          if$
+        }
+        { editor format.lab.names }
+      if$
+    }
+    { author format.lab.names }
+  if$
+}
+
 FUNCTION { calc.basic.label }
 {
   type$ "book" =
@@ -2386,7 +2390,7 @@ FUNCTION { calc.basic.label }
     { type$ "proceedings" =
         'editor.key.organization.label
         { type$ "manual" =
-            'author.key.organization.label
+            'author.editor.key.organization.label
             'author.key.label
           if$
         }
@@ -2397,7 +2401,7 @@ FUNCTION { calc.basic.label }
 
 FUNCTION { calc.label }
 {
-  % Changed - GNP. See also author.organization.sort, editor.organization.sort
+  % Changed - GNP. See also author.editor.organization.sort, editor.organization.sort
   % Form label for BibTeX entry. The classification of which fields are used
   % for which type of entry (book, inbook, etc.) are taken from alpha.bst.
   % The change here from newapa is to also include organization as a
@@ -3212,27 +3216,6 @@ FUNCTION { author.editor.sort }
   if$
 }
 
-FUNCTION { author.organization.sort }
-{
-  % added - GNP. Stack author or organization for sorting (from alpha.bst).
-  % Unlike alpha.bst, we need entire names, not abbreviations
-
-  author empty.or.unknown
-    { organization empty.or.unknown
-        { key empty.or.unknown
-            { "to sort, need author, organization, or key in " cite$ * warning$
-              ""
-            }
-            { key sortify }
-          if$
-        }
-        { organization sortify }
-      if$
-    }
-    { author sort.format.names }
-  if$
-}
-
 FUNCTION { editor.organization.sort }
 {
   % added - GNP. Stack editor or organization for sorting (from alpha.bst).
@@ -3251,6 +3234,32 @@ FUNCTION { editor.organization.sort }
       if$
     }
     { editor sort.format.names }
+  if$
+}
+
+FUNCTION { author.editor.organization.sort }
+{
+  % added - GNP. Stack author or organization for sorting (from alpha.bst).
+  % Unlike alpha.bst, we need entire names, not abbreviations
+
+  author empty.or.unknown
+    {
+      editor empty.or.unknown
+        { organization empty.or.unknown
+            { key empty.or.unknown
+                { "to sort, need author, editor, or key in " cite$ * warning$
+                ""
+                }
+                { key sortify }
+              if$
+            }
+            { organization sortify }
+          if$
+        }
+        { editor sort.format.names }
+      if$
+    }
+    { author sort.format.names }
   if$
 }
 
@@ -3274,7 +3283,7 @@ FUNCTION { presort }
     { type$ "proceedings" =
         'editor.organization.sort
         { type$ "manual" =
-            'author.organization.sort
+            'author.editor.organization.sort
             'author.sort
           if$
         }


### PR DESCRIPTION
When doing stress tests, I found a few bugs in sorting of the BibTeX entry types.  These two commits fix those.

The first bug was that `periodical` entry types (which have an `editor` but no `author`) were being sorted incorrectly in the generated "References" list.

The second bug was that "no key, author in ..." warnings from BibTeX were happening on things like `book` when they had an `editor` but no `author`.  (The code in `presort` and `calc.label` call things like `author.editor.sort` and `author.editor.key.label`, which indicates they should be able to be used with an `author` but no `editor`.)

The first bug is fixed by 4acfca33ca5b6812450e473e63dbe5b56207243b. The second bug is fixed by fc294669ada99eb82fcae41790558b8378f801a0.  Descriptions of how these fixes were implemented are in the respective commit messages.