### PR TITLE
Remove spurious "numpages field, but no articleno field" warning

### DIFF
--- a/ACM-Reference-Format.bst
+++ b/ACM-Reference-Format.bst
@@ -1601,13 +1601,7 @@ FUNCTION { format.page.count }
 {
   page.count empty.or.unknown
     { "" }
-    {
-      articleno empty.or.unknown
-        { "numpages field, but no articleno field, in " cite$ * warning$ }
-        { }
-      if$
-      "\bibinfo{numpages}{" page.count * "}~pages" *
-    }
+    { "\bibinfo{numpages}{" page.count * "}~pages" * }
   if$
 }
 
@@ -1633,7 +1627,7 @@ FUNCTION { format.articleno.numpages }
     {
       numpages empty.or.unknown
         { }
-        { "require articleno with numpages field in " cite$ * warning$ }
+        { "numpages field, but no articleno field, in " cite$ * warning$ }
       if$
       ""
     }
@@ -1642,7 +1636,7 @@ FUNCTION { format.articleno.numpages }
         {
           pages empty.or.unknown
             {
-              "require pages or numpages fields with articleno field in " cite$ * warning$
+              "articleno, but no pages or numpages field in " cite$ * warning$
               "" 'page.count :=
             }
             { reduce.pages.to.page.count }


### PR DESCRIPTION
The containing function, `format.page.count`, didn't actually check if the
`numpages` field is empty.  That function was called from two places.  The
first is in `format.articleno.numpages`, which already checks and issues
warnings for this.  The second is in `calc.format.page.count` and doesn't
check if `numpages` is empty.  Thus this warning could be issued on entries
for which there was no `numpages` field.

Since the first place already checks and warns and the second place isn't
related to anything having to do with `articleno` the fix is to just remove
the warning.

This commit also reformats a couple warnings to be consistent with the
warnings in the rest of the file.