### PR TITLE
Remove duplicated year from header

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -5065,9 +5065,9 @@ Computing Machinery]
     \fancyhead[LO]{\ACM@linecountL\@headfootfont\shorttitle}%
     \fancyhead[RE]{\@headfootfont\@shortauthors\ACM@linecountR}%
     \fancyhead[LE]{\ACM@linecountL\@headfootfont\acmConference@shortname,
-      \acmConference@date, \acmConference@venue}%
+      \acmConference@venue}%
     \fancyhead[RO]{\@headfootfont\acmConference@shortname,
-      \acmConference@date, \acmConference@venue\ACM@linecountR}%
+      \acmConference@venue\ACM@linecountR}%
   \fi
   \if@ACM@sigchiamode
      \fancyheadoffset[L]{\dimexpr(\marginparsep+\marginparwidth)}%


### PR DESCRIPTION
The style guide shows that the `short name` of a conference should include the
year, such as:

    \acmConference[SenSys'17]{The 15th ACM Conference on Embedded Networked Sensor Systems}{November 6-8, 2017}{Delft, The Netherlands}

Prior to this patch, that creates column headers that look like:

    SenSys'17, November 6-8, 2017, Delft, The Netherlands

Which is visually confusing and redundant to have both `'17` and 2017.
It is also simply a lot of text at the top of each column.

After this patch, the header simply reads:

    SenSys'17, Delft, The Netherlands