### PR TITLE
Fix typo in the docs.

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1053,7 +1053,7 @@
 %\subsection{Algorithms}
 %\label{sec:ug_algorithms}
 %
-% There now several good packages for typesetting
+% There are now several good packages for typesetting
 % algorithms~\cite{Fiorio15, Brito09, Heinz15}, and the authors are
 % now free to choose their favorite one.
 %


### PR DESCRIPTION
(Missing `are`)