### PR TITLE
Remove latex-tools from list of included packages

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -168,7 +168,6 @@
 % \item \textsl{ifluatex}, \url{http://www.ctan.org/pkg/ifluatex}
 % \item \textsl{ifxetex}, \url{http://www.ctan.org/pkg/ifxetex}
 % \item \textsl{inconsolata}, \url{http://www.ctan.org/pkg/inconsolata}
-% \item \textsl{latex-tools}, \url{http://www.ctan.org/pkg/latex-tools}
 % \item \textsl{libertine}, \url{http://www.ctan.org/pkg/libertine}
 % \item \textsl{manyfoot}, \url{http://www.ctan.org/pkg/manyfoot}
 % \item \textsl{microtype}, \url{http://www.ctan.org/pkg/microtype}


### PR DESCRIPTION
The documentation file acmguide.pdf, Section 2.1 Installation, states that latex-tools is "used by" acmart, which I take to mean that the package is included automatically when acmart is used as the document class. However, this doesn't seem to be the case, as "latex-tools" does not appear in my compilation logfile, nor does it appear (outside the documentation) in the acmart code repository.

I've dug through the Git history and this is what I've found: In bfef68f3bd96e3ee046f9be913a6bcb2c2aab92d (in response to issue #13) it was added to acmguide.pdf that the "tools" package is automatically included by acmart. In ec68da1fe9033e45d6b2b16c1f0436e9389da208 (in response to issue #38), the reference to "tools" was replaced with a reference to "latex-tools". However, neither "tools" nor "latex-tools" has ever been included in acmart, at least as far as I can tell from the Git history which dates back to April 2016 with the initial commit 3b8cfca6d4b4a927ba11a766d7099226e764cfef.

I assume this means I'm safe to include latex-tools (or rather, enumerate) in my manuscript for SIGSPATIAL 2017. However, the documentation or the class should probably 