### PR TITLE
Fix underfull hbox warning due to line numbering

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -5373,11 +5373,13 @@ Computing Machinery]
   \ACM@linecount\@ne\relax
   \def\ACM@mk@linecount{%
     \savebox{\ACM@linecount@bx}[4em][t]{\parbox[t]{4em}{%
-        \setlength{\ACM@linecount@bxht}{-\baselineskip}%
+        \setlength{\ACM@linecount@bxht}{0pt}%
         \loop{\color{red}\scriptsize\the\ACM@linecount}\\
         \global\advance\ACM@linecount by \@ne
         \addtolength{\ACM@linecount@bxht}{\baselineskip}%
-        \ifdim\ACM@linecount@bxht<\textheight\repeat}}}
+        \ifdim\ACM@linecount@bxht<\textheight\repeat
+        {\color{red}\scriptsize\the\ACM@linecount}\hfill
+        \global\advance\ACM@linecount by \@ne}}}
 \fi
 %    \end{macrocode}
 %


### PR DESCRIPTION
Enabling `review` mode causes underfull hbox warnings due to the line numbering. Since `\\` expands to `\hfill\break`, the `\break` causes a new underfull hbox after the last line in each column.

Iterate one time less in the loop and output the last line number after the loop with just a `\hfill` to fix this.