### PR TITLE
Reintegrate theorem code into acmart.dtx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 acmart.cls
-acmthm.sty
 acmart.pdf
 acmguide.pdf
 sample-*.pdf

--- a/README
+++ b/README
@@ -134,7 +134,7 @@ Version 1.43    Bug fixes
 
 Version 1.44    Bug fixes.
 		Empty DOI and ISBN suppress printing DOI or ISBN lines
-		Separated theorem code into acmthm.sty, loaded by defualt.
+		Separated theorem code into acmthm.sty, loaded by default.
 		Article number can be set for proceedings.
 		New commands: \acmBooktile, \editor.
 		Reference citation format updated.
@@ -152,4 +152,5 @@ Version 1.46    Bug fixes for bibliography:  label width is now calculated
 		\authorsaddresses command.
 		Deleted the rule at the end of frontmatter for all formats.
 		Deleted new line before doi in the reference format.
-		
+
+Version 1.47    Reintegrated theorem code into acmart.dtx.

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -15,8 +15,8 @@
 % The Current Maintainer of this work is Boris Veytsman,
 % <borisv@lk.net>
 %
-% This work consists of the file acmart.dtx, the derived files
-% acmart.cls, acmthm.sty, the files ACM-Reference-Format.bst, and templates
+% This work consists of the file acmart.dtx, the derived file
+% acmart.cls, the files ACM-Reference-Format.bst, and templates
 % sample-acmlarge.tex, sample-acmsmall.tex, sample-acmtog.tex,
 % samplebody-conf.tex, samplebody-journals.tex, sample-manuscript.tex,
 % sample-sigchi-a.tex, sample-sigchi.tex,
@@ -161,9 +161,9 @@
 % and rather rely on their \TeX\ distributions to provide it.  If you
 % decide to install the package yourself, follow the standard rules:
 % \begin{enumerate}
-% \item Run \progname{latex} on |acmart.ins|.  This will produce the files
-% |acmart.cls| and |acmthm.sty|
-% \item Put the files |acmart.cls|, |acmthm.sty| 
+% \item Run \progname{latex} on |acmart.ins|.  This will produce the file
+% |acmart.cls|
+% \item Put the file |acmart.cls|
 %   and the bibliography files |*.bst|
 %   to the places where \LaTeX{} can find them (see \cite{TeXFAQ} or
 %   the documentation for your \TeX{} system).\label{item:install}
@@ -356,7 +356,7 @@
 %     timestamp & false & Whether to put a time stamp in the
 %     footer of each page\\
 %     authordraft & false & Whether author's draft mode is enabled\\
-%     acmthm & true & Whether to load |acmthm.sty|, see
+%     acmthm & true & Whether to define theorem-like environments, see
 %     Section~\ref{sec:ug_theorems}\\
 %     \bottomrule
 %   \end{tabularx}
@@ -1259,18 +1259,10 @@
 % \end{description}
 %
 %
-% These definitions are in the separate style file |acmthm.sty|, which
-% is loaded by default.  However, sometimes the user might want to
-% delay loading this package, for example, if she wants for load
-% package like |cleveref| first.  In this case use the option
-% |acmthm=false| in the preamble, for example,
-% \begin{verbatim}
-% \documentclass[acmsmall, acmthm=false]{acmart}
-% \usepackage{cleveref}
-% \usepackage{acmthm}
-% \end{verbatim}
-% 
-%
+% These environments are defined by default.  In the unusual
+% circumstance that a user does not wish to have these environments
+% defined, the option |acmthm=false| in the preamble will suppress
+% them.
 %
 %\subsection{Online-only and offline-only material}
 %\label{sec:ug_screen}
@@ -1658,8 +1650,7 @@
 \ProvidesFile{acmart.dtx}
 %</gobble>
 %<class>\ProvidesClass{acmart}
-%<acmthm>\ProvidesPackage{acmthm}
-[2017/08/26 v1.46 Typesetting articles for Association of
+[2017/08/29 v1.47 Typesetting articles for Association of
 Computing Machinery]
 %    \end{macrocode}
 %
@@ -1729,6 +1720,7 @@ Computing Machinery]
 % \changes{v1.46}{2017/08/17}{Bst file bug fixes: label width is
 % calculated correctly}
 % \changes{v1.46}{2017/08/25}{Added etoolbox}
+% \changes{v1.47}{2017/08/29}{Restore theorem defs to class file}
 %
 %
 % And the driver code:
@@ -1822,7 +1814,8 @@ Computing Machinery]
 %
 % \begin{macro}{\if@ACM@acmthm}
 % \changes{v1.44}{2017/07/30}{Added macro}
-%   Whether we load |acmthm|
+% \changes{v1.47}{2017/08/29}{Modified description}
+%   Whether we define theorem-like environments.
 %    \begin{macrocode}
 \define@boolkey+{acmart.cls}[@ACM@]{acmthm}[true]{%
   \if@ACM@acmthm
@@ -5913,18 +5906,9 @@ Computing Machinery]
 %\subsection{Theorems}
 %\label{sec:theorems}
 %
-% The conditional loading
-%    \begin{macrocode}
-\if@ACM@acmthm
-  \RequirePackage{acmthm}
-\fi
-%    \end{macrocode}
-% 
 % \begin{macro}{\@acmplainbodyfont}
 %   The font to typeset the |acmplain| theorem style body.
 %    \begin{macrocode}
-%</class>
-%<*acmthm>
 \def\@acmplainbodyfont{\itshape}
 %    \end{macrocode}
 %
@@ -6061,18 +6045,49 @@ Computing Machinery]
 %
 % \end{macro}
 %
-% The definitions for theorems:
+% Make |acmplain| the default theorem style.
 %    \begin{macrocode}
 \theoremstyle{acmplain}
-\newtheorem{theorem}{Theorem}[section]
-\newtheorem{conjecture}[theorem]{Conjecture}
-\newtheorem{proposition}[theorem]{Proposition}
-\newtheorem{lemma}[theorem]{Lemma}
-\newtheorem{corollary}[theorem]{Corollary}
-\theoremstyle{acmdefinition}
-\newtheorem{example}[theorem]{Example}
-\newtheorem{definition}[theorem]{Definition}
-\theoremstyle{acmplain}
+%    \end{macrocode}
+%
+% Delay defining the theorem environments until after other packages
+% have been loaded.  In particular, the |cleveref| package must be
+% loaded before the theorem environments are defined in order to show
+% the correct environment name (see
+% https://github.com/borisveytsman/acmart/issues/138).  The |acmthm|
+% option is used to suppress the definition of any theorem
+% environments.  Also, to avoid obscure errors arising from these
+% environment definitions conflicting with environments defined by the
+% user or by user-loaded packages, we only define environments that
+% have not yet been defined.
+%    \begin{macrocode}
+\AtEndPreamble{%
+  \if@ACM@acmthm
+  \theoremstyle{acmplain}
+  \@ifundefined{theorem}{%
+  \newtheorem{theorem}{Theorem}[section]
+  }{}
+  \@ifundefined{conjecture}{%
+  \newtheorem{conjecture}[theorem]{Conjecture}
+  }{}
+  \@ifundefined{proposition}{%
+  \newtheorem{proposition}[theorem]{Proposition}
+  }{}
+  \newtheorem{lemma}[theorem]{Lemma}
+  \@ifundefined{lemma}{}{}
+  \@ifundefined{corollary}{%
+  \newtheorem{corollary}[theorem]{Corollary}
+  }{}
+  \theoremstyle{acmdefinition}
+  \@ifundefined{example}{%
+  \newtheorem{example}[theorem]{Example}
+  }{}
+  \@ifundefined{definition}{%
+  \newtheorem{definition}[theorem]{Definition}
+  }{}
+  \fi
+  \theoremstyle{acmplain}
+}
 %    \end{macrocode}
 %
 %
@@ -6121,8 +6136,6 @@ Computing Machinery]
 }{%
   \popQED\endtrivlist\@endpefalse
 }
-%</acmthm>
-%<*class>
 %    \end{macrocode}
 %
 % \end{macro}

--- a/acmart.ins
+++ b/acmart.ins
@@ -13,7 +13,6 @@
 
 \generate{%
   \file{acmart.cls}{\from{acmart.dtx}{class}}
-  \file{acmthm.sty}{\from{acmart.dtx}{acmthm}}
 }
 
 \obeyspaces
@@ -21,9 +20,9 @@
 \Msg{* Congratulations!  You successfully  generated the *}%
 \Msg{* acmart package.                                   *}%
 \Msg{*                                                   *}%
-\Msg{* Please move the files acmart.cls and acmthm.sty   *}%
-\Msg{* to the location where LaTeX files are stored in   *}%
-\Msg{* your system.  The manual is acmart.pdf.           *}%
+\Msg{* Please move the file acmart.cls to where LaTeX    *}%
+\Msg{* files are stored in  your system.  The manual is  *}%
+\Msg{* acmart.pdf.                                       *}%
 \Msg{*                                                   *}%
 \Msg{* The package is released under LPPL                *}%
 \Msg{*                                                   *}%


### PR DESCRIPTION
Proposed solution to #196

There are a number of disadvantages to a separate `acmthm.sty` file:
 * It is another file to manage when using a distribution that does
 not provide an up-to-date acmart package (e.g., Ubuntu 16.04 LTS).
 * Authors may use `acmthm=false` but never `\usepackage{acmthm}`,
 either through oversight or because they discover that it conflicts
 with their `\newtheorem{theorem}`; in either case, the author will
 not be using the `acmplain` `\theoremstyle`.

The original reason for factoring the theorem code into `acmthm.sty`
was to allow `cleveref` to be loaded before the theorem code,
addressing an issue where `cleveref` failed to use the correct
label (see https://github.com/borisveytsman/acmart/issues/138).  This
commit addresses that issue by delaying the definition of the theorem
environments until `\AtEndPreamble`, after `cleveref` has been
loaded.