### PR TITLE
More fixes for #212

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -4917,7 +4917,7 @@ Computing Machinery]
   \def\institution#1{\unskip~#1\ignorespaces}
   \def\city#1{\unskip\ignorespaces}
   \def\state#1{\unskip\ignorespaces}
-  \newcommand\department[2][0]{}
+  \newcommand\department[2][0]{\unskip\ignorespaces}
   \def\country#1{\if@ACM@affiliation@obeypunctuation\else, \fi#1\ignorespaces}
 \else
   \def\position#1{\if@ACM@affiliation@obeypunctuation#1\else#1\par\fi}%


### PR DESCRIPTION
The following remained with an extra space before the institution:

    \author{Author}
    \affiliation{
      \department{Department2}
      \institution{Institution}
      \streetaddress{Street Address}
      \city{City}
      \state{State}
      \postcode{Post-Code}
      \country{Country}
    }

    \author{Author}
    \affiliation{%
      \institution{Institution}
      \country{Country}
    }
    \affiliation{
      \department{Department2}
      \institution{Institution}
      \streetaddress{Street Address}
      \city{City}
      \state{State}
      \postcode{Post-Code}
      \country{Country}
    }