### PR TITLE
Fix various typos

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1368,8 +1368,8 @@
 %   Science Foundation of
 %   China}{https://doi.org/10.13039/501100001809} under Grant
 %   No.:~\grantnum{GS501100001809}{61273304}
-%   and~\grantnum[http://www.nnsf.cn/youngscientsts]{GS501100001809}{Young 
-%   Scientsts' Support Program}.
+%   and~\grantnum[http://www.nnsf.cn/youngscientists]{GS501100001809}{Young
+%   Scientists' Support Program}.
 % \end{acks}
 % \end{verbatim}
 % 

--- a/sample-acmlarge.tex
+++ b/sample-acmlarge.tex
@@ -198,7 +198,7 @@ multi-channel, radio interference, time synchronization}
 
 \maketitle
 
-% The default list of authors is too long for headers}
+% The default list of authors is too long for headers.
 \renewcommand{\shortauthors}{G. Zhou et al.}
 
 \input{samplebody-journals}

--- a/sample-acmsmall.tex
+++ b/sample-acmsmall.tex
@@ -177,7 +177,7 @@ multi-channel, radio interference, time synchronization}
 
 \maketitle
 
-% The default list of authors is too long for headers}
+% The default list of authors is too long for headers.
 \renewcommand{\shortauthors}{G. Zhou et al.}
 
 \input{samplebody-journals}

--- a/sample-sigchi-a.tex
+++ b/sample-sigchi-a.tex
@@ -75,7 +75,7 @@
   \city{Pretoria} \country{South Africa}}
 \email{author7@umbhaliu.ac.za} 
 
-% The default list of authors is too long for headers}
+% The default list of authors is too long for headers.
 \renewcommand{\shortauthors}{F. Author et al.}
 
 

--- a/sample-sigchi.tex
+++ b/sample-sigchi.tex
@@ -109,7 +109,7 @@
 \affiliation{\institution{The Kumquat Consortium}}
 \email{jpkumquat@consortium.net}
 
-% The default list of authors is too long for headers}
+% The default list of authors is too long for headers.
 \renewcommand{\shortauthors}{B. Trovato et al.}
 
 

--- a/sample-sigconf-authordraft.tex
+++ b/sample-sigconf-authordraft.tex
@@ -103,7 +103,7 @@
 \affiliation{\institution{The Kumquat Consortium}}
 \email{jpkumquat@consortium.net}
 
-% The default list of authors is too long for headers}
+% The default list of authors is too long for headers.
 \renewcommand{\shortauthors}{B. Trovato et al.}
 
 

--- a/sample-sigconf.tex
+++ b/sample-sigconf.tex
@@ -118,7 +118,7 @@
 \affiliation{\institution{The Kumquat Consortium}}
 \email{jpkumquat@consortium.net}
 
-% The default list of authors is too long for headers}
+% The default list of authors is too long for headers.
 \renewcommand{\shortauthors}{B. Trovato et al.}
 
 

--- a/sample-sigplan.tex
+++ b/sample-sigplan.tex
@@ -112,7 +112,7 @@
 \email{jpkumquat@consortium.net}
 
 
-% The default list of authors is too long for headers}
+% The default list of authors is too long for headers.
 \renewcommand{\shortauthors}{B. Trovato et al.}
 
 

--- a/samplebody-conf.tex
+++ b/samplebody-conf.tex
@@ -370,7 +370,7 @@ code.
 
 \begin{acks}
   The authors would like to thank Dr. Yuhua Li for providing the
-  matlab code of  the \textit{BEPS} method. 
+  MATLAB code of the \textit{BEPS} method.
 
   The authors would also like to thank the anonymous referees for
   their valuable comments and helpful suggestions. The work is
@@ -378,7 +378,7 @@ code.
     Science Foundation of
     China}{http://dx.doi.org/10.13039/501100001809} under Grant
   No.:~\grantnum{GS501100001809}{61273304}
-  and~\grantnum[http://www.nnsf.cn/youngscientsts]{GS501100001809}{Young
-    Scientsts' Support Program}.
+  and~\grantnum[http://www.nnsf.cn/youngscientists]{GS501100001809}{Young
+    Scientists' Support Program}.
 
 \end{acks}

--- a/samplebody-journals.tex
+++ b/samplebody-journals.tex
@@ -80,7 +80,7 @@ to avoid Hidden Terminal Problems in the 802.11 standard and
 protocols based on those similar to \cite{Akyildiz-01} and
 \cite{Adya-01}.} for frequency negotiation and reservation are not
 suitable for WSN applications, even though they exhibit good
-performance in general wireless ad hoc
+performance in general wireless ad-hoc
 networks.
 
 % Head 3
@@ -230,7 +230,7 @@ coalescing were made).
 
 \section{Performance Evaluation}
 
-During all the experiments, the Geographic Forwarding (GF) by Akuilidz
+During all the experiments, the Geographic Forwarding (GF) by Akyildiz
 et al.~\shortcite{Akyildiz-01} routing protocol is used. GF exploits
 geographic information of nodes and conducts local data-forwarding to
 achieve end-to-end routing. Our simulation is configured according to
@@ -373,8 +373,8 @@ The work is supported by the \grantsponsor{GS501100001809}{National
   Natural Science Foundation of
   China}{http://dx.doi.org/10.13039/501100001809} under Grant
 No.:~\grantnum{GS501100001809}{61273304\_a}
-and~\grantnum[http://www.nnsf.cn/youngscientsts]{GS501100001809}{Young
-  Scientsts' Support Program}.
+and~\grantnum[http://www.nnsf.cn/youngscientists]{GS501100001809}{Young
+  Scientists' Support Program}.
 
 
 \end{acks}


### PR DESCRIPTION
1. Fix punctuation in a comment.

"% The default list of authors is too long for headers}"
	becomes
"% The default list of authors is too long for headers."

2. "ad hoc" -> "ad-hoc" for consistency.

3. Fix spelling of fictional Young Scientist's Support Program
                                         ^ The "i" was missing.

4. "matlab" -> "MATLAB" per the MathWorks spelling convention.

5. Fix author's name in sample text: it's "Akyildiz", not "Akuilidz".