### PR TITLE
Improved formatting of the timestamp

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -5509,12 +5509,12 @@ Computing Machinery]
   \setcounter{ACM@time@minutes}{\numexpr \time - \theACM@time@hours * 60 \relax}
   \newcommand\ACM@timestamp{%
     \footnotesize%
-    \the\year-\two@digits{\the\month}-\two@digits{\the\day}{ }%
-    \two@digits{\theACM@time@hours}:\two@digits{\theACM@time@minutes}{ }%
-    page~\thepage\ (pp. \@startPage-\pageref*{TotPages})%
     \ifx\@acmSubmissionID\@empty\relax\else
-    ~Submission~ID: \@acmSubmissionID
+    Submission ID: \@acmSubmissionID.{ }%
     \fi
+    \the\year-\two@digits{\the\month}-\two@digits{\the\day}{ }%
+    \two@digits{\theACM@time@hours}:\two@digits{\theACM@time@minutes}{. }%
+    Page \thepage\ of \@startPage--\pageref*{TotPages}.%
   }
 \fi
 %    \end{macrocode}


### PR DESCRIPTION
- Moved "Submission Id: X" to the start of the timestamp so components
  (i.e., Submission Id, time and page numbers) are ordered from largest to
  smallest conceptually

- Added `.` after each timestamp component

- Changed "page X (pp. Y-Z)" to "Page X of Y--Z"

- Replaced `~` that did not seem to be needed with ` `