### PR TITLE
Remove duplicate `\def`

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -3279,14 +3279,12 @@ Computing Machinery]
   \def\@permissionCodeOne{0730-0301}
 \or % TOIS
   \def\@journalName{ACM Transactions on Information Systems}%
-  \def\@journalName{ACM Transactions on Information Systems}%
   \def\@permissionCodeOne{1046-8188}%
 \or % TOIT
   \def\@journalName{ACM Transactions on Internet Technology}%
   \def\@journalNameShort{ACM Trans. Internet Technol.}%
   \def\@permissionCodeOne{1533-5399}%
 \or % TOMACS
-  \def\@journalName{ACM Transactions on Modeling and Computer Simulation}%
   \def\@journalName{ACM Transactions on Modeling and Computer Simulation}%
   \def\@journalNameShort{ACM Trans. Model. Comput. Simul.}%
 \or % TOMM


### PR DESCRIPTION
I'm not sure if these are just duplicates or maybe these should actually be `\def\@journalNameShort`.