### PR TITLE
Fix incomplete empty DOI handling when \acmDOI{} is used 

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -5431,7 +5431,7 @@ Computing Machinery]
      ACM, New York, NY, USA%
        \@article@string\unskip, \ref{TotPages}~\@pages@word.
   \fi
-  \@formatdoi{\@acmDOI}
+  \ifx\@acmDOI\@empty\else\@formatdoi{\@acmDOI}\fi
 \par\egroup}
 %    \end{macrocode}
 %


### PR DESCRIPTION
I was using 1.48 and `\acmDOI{}` rendered me with `...es. https://doi.org/` in the "ACM Reference Format:" section as in "Zexing Xu. 2017. Story-telling within VR Film Production: Extended Abstract. In Proceedings of the Entertainment Technology Summit and Exhibition + Women’s Voice, Serguei A. Mokhov, Miao Song, and Sudhir P. Mudur (Eds.). ACM, New York, NY, USA, 20 pages. https://doi.org/". This onliner fix replicates what was done for the `% Conference` section but was forgotten here.