### PR TITLE
Add a 'nonacm' option to produce standalone documents

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -360,6 +360,9 @@
 %     authorversion & false & Whether to generate a special
 %     version for the authors' personal use or posting (see
 %     Section~\ref{sec:ug_topmatter})\\
+%     nonacm & false & Use the class typesetting options for
+%     a non-ACM document, which will not include the conference/journal
+%     header and footers or permission statements\\
 %     timestamp & false & Whether to put a time stamp in the
 %     footer of each page\\
 %     authordraft & false & Whether author's-draft mode is enabled\\
@@ -1913,6 +1916,26 @@ Computing Machinery]
 %
 % \end{macro}
 %
+% \begin{macro}{\if@ACM@nonacm}
+% \changes{v1.54}{2018/05/08}{Added macro}
+%   Special option for non-ACM publications
+%   using the ACM typesetting options.
+%    \begin{macrocode}
+\define@boolkey+{acmart.cls}[@ACM@]{nonacm}[true]{%
+  \if@ACM@nonacm
+    \PackageInfo{\@classname}{Using nonacm mode}%
+    \AtBeginDocument{\@ACM@printacmreffalse}%
+    % in 'nonacm' mode we disable the "ACM Reference Format"
+    % printing by default, but this can be re-enabled by the
+    % user using \settopmatter{printacmref=true}
+  \else
+    \PackageInfo{\@classname}{Not using nonacm mode}%
+  \fi}{\PackageError{\@classname}{The option nonacm can be either true or
+    false}}
+\ExecuteOptionsX{nonacm=false}
+%    \end{macrocode}
+%
+% \end{macro}
 %
 % \begin{macro}{\if@ACM@natbib@override}
 % \changes{v1.12}{2016/05/30}{Added macro}
@@ -4638,7 +4661,7 @@ Computing Machinery]
        \fi
      \fi
   \fi
-  \footnotetextcopyrightpermission{%
+  \if@ACM@nonacm\else\footnotetextcopyrightpermission{%
     \if@ACM@authordraft
         \raisebox{-2ex}[\z@][\z@]{\makebox[0pt][l]{\large\bfseries
             Unpublished working draft. Not for distribution.}}%
@@ -4656,7 +4679,7 @@ Computing Machinery]
     \if@printcopyright
       \copyright\ \@copyrightyear\ \@copyrightowner\\
     \else
-     \@copyrightyear.\
+      \@copyrightyear.\
     \fi
     \if@ACM@manuscript
       Manuscript submitted to ACM\\
@@ -4676,17 +4699,20 @@ Computing Machinery]
             , \@formatdoi{\@acmDOI}.
           \fi\\
         \else
-          \if@ACM@journal
-            \@permissionCodeOne/\@acmYear/\@acmMonth-ART\@acmArticle
-            \ifx\@acmPrice\@empty\else\ \$\@acmPrice\fi\\
-            \@formatdoi{\@acmDOI}%
-          \else % Conference
-            \ifx\@acmISBN\@empty\else ACM~ISBN~\@acmISBN
-            \ifx\@acmPrice\@empty.\else\dots\$\@acmPrice\fi\\\fi
-            \ifx\@acmDOI\@empty\else\@formatdoi{\@acmDOI}\fi%
+          \if@ACM@nonacm\else
+            \if@ACM@journal
+              \@permissionCodeOne/\@acmYear/\@acmMonth-ART\@acmArticle
+              \ifx\@acmPrice\@empty\else\ \$\@acmPrice\fi\\
+              \@formatdoi{\@acmDOI}%
+            \else % Conference
+              \ifx\@acmISBN\@empty\else ACM~ISBN~\@acmISBN
+              \ifx\@acmPrice\@empty.\else\dots\$\@acmPrice\fi\\\fi
+              \ifx\@acmDOI\@empty\else\@formatdoi{\@acmDOI}\fi%
+            \fi
           \fi
         \fi
       \fi}
+    \fi
   \endgroup
   \setcounter{footnote}{0}%
   \@mkabstract
@@ -5531,17 +5557,23 @@ Computing Machinery]
   \par\medskip\small\noindent{\bfseries ACM Reference Format:}\par\nobreak
   \noindent\authors. \@acmYear. \@title
   \ifx\@subtitle\@empty. \else: \@subtitle. \fi
-  \if@ACM@journal
-     \textit{\@journalNameShort}
-     \@acmVolume, \@acmNumber \@article@string (\@acmPubDate),
-     \ref{TotPages}~\@pages@word.
-  \else
-     In \textit{\@acmBooktitle}%
-     \ifx\@acmEditors\@empty\textit{.}\else
-       \andify\@acmEditors\textit{, }\@acmEditors~\@editorsAbbrev.%
-     \fi\
-     ACM, New York, NY, USA%
-       \@article@string\unskip, \ref{TotPages}~\@pages@word.
+  \if@ACM@nonacm\else
+    % The 'nonacm' option disables 'printacmref' by default,
+    % and the present \@mkbibcitation definition is never used
+    % in this case. The conditional remains useful if the user
+    % explicitly sets \settopmatter{printacmref=true}.
+    \if@ACM@journal
+       \textit{\@journalNameShort}
+       \@acmVolume, \@acmNumber \@article@string (\@acmPubDate),
+       \ref{TotPages}~\@pages@word.
+    \else
+       In \textit{\@acmBooktitle}%
+       \ifx\@acmEditors\@empty\textit{.}\else
+         \andify\@acmEditors\textit{, }\@acmEditors~\@editorsAbbrev.%
+       \fi\
+       ACM, New York, NY, USA%
+         \@article@string\unskip, \ref{TotPages}~\@pages@word.
+    \fi
   \fi
   \ifx\@acmDOI\@empty\else\@formatdoi{\@acmDOI}\fi
 \par\egroup}
@@ -5715,22 +5747,28 @@ Computing Machinery]
     \fancyhead[RO]{\if@ACM@printfolios\thepage\fi}%
     \fancyhead[RE]{\@shortauthors}%
     \fancyhead[LO]{\ACM@linecountL\shorttitle}%
-    \fancyfoot[RO,LE]{\footnotesize Manuscript submitted to ACM}%
+    \if@ACM@nonacm\else%
+      \fancyfoot[RO,LE]{\footnotesize Manuscript submitted to ACM}
+    \fi%
   \or % acmsmall
     \fancyhead[LE]{\ACM@linecountL\@headfootfont\@acmArticle\if@ACM@printfolios:\thepage\fi}%
     \fancyhead[RO]{\@headfootfont\@acmArticle\if@ACM@printfolios:\thepage\fi}%
     \fancyhead[RE]{\@headfootfont\@shortauthors}%
     \fancyhead[LO]{\ACM@linecountL\@headfootfont\shorttitle}%
-    \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
-    \@acmNumber, Article \@acmArticle.  Publication date: \@acmPubDate.}%
+    \if@ACM@nonacm\else%
+      \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
+      \@acmNumber, Article \@acmArticle.  Publication date: \@acmPubDate.}%
+    \fi%
   \or % acmlarge
     \fancyhead[LE]{\ACM@linecountL\@headfootfont
       \@acmArticle\if@ACM@printfolios:\thepage\fi\quad\textbullet\quad\@shortauthors}%
     \fancyhead[LO]{\ACM@linecountL}%
     \fancyhead[RO]{\@headfootfont
       \shorttitle\quad\textbullet\quad\@acmArticle\if@ACM@printfolios:\thepage\fi}%
-    \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
-    \@acmNumber, Article \@acmArticle.  Publication date: \@acmPubDate.}%
+    \if@ACM@nonacm\else%
+      \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
+      \@acmNumber, Article \@acmArticle.  Publication date: \@acmPubDate.}%
+    \fi%
   \or % acmtog
     \fancyhead[LE]{\ACM@linecountL\@headfootfont
       \@acmArticle\if@ACM@printfolios:\thepage\fi\quad\textbullet\quad\@shortauthors}%
@@ -5738,16 +5776,20 @@ Computing Machinery]
     \fancyhead[RE]{\ACM@linecountR}%
     \fancyhead[RO]{\@headfootfont
       \shorttitle\quad\textbullet\quad\@acmArticle\if@ACM@printfolios:\thepage\fi\ACM@linecountR}%
-    \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
-    \@acmNumber, Article \@acmArticle.  Publication date: \@acmPubDate.}%
+    \if@ACM@nonacm\else%
+      \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
+      \@acmNumber, Article \@acmArticle.  Publication date: \@acmPubDate.}%
+    \fi%
   \else % Proceedings
     \fancyfoot[C]{\if@ACM@printfolios\footnotesize\thepage\fi}%
     \fancyhead[LO]{\ACM@linecountL\@headfootfont\shorttitle}%
     \fancyhead[RE]{\@headfootfont\@shortauthors\ACM@linecountR}%
-    \fancyhead[LE]{\ACM@linecountL\@headfootfont\acmConference@shortname,
-      \acmConference@date, \acmConference@venue}%
-    \fancyhead[RO]{\@headfootfont\acmConference@shortname,
-      \acmConference@date, \acmConference@venue\ACM@linecountR}%
+    \if@ACM@nonacm\else%
+      \fancyhead[LE]{\ACM@linecountL\@headfootfont\acmConference@shortname,
+        \acmConference@date, \acmConference@venue}%
+      \fancyhead[RO]{\@headfootfont\acmConference@shortname,
+        \acmConference@date, \acmConference@venue\ACM@linecountR}%
+    \fi%
   \fi
   \if@ACM@sigchiamode
      \fancyheadoffset[L]{\dimexpr(\marginparsep+\marginparwidth)}%
@@ -5847,27 +5889,35 @@ Computing Machinery]
   \relax % manuscript
     \fancyhead[L]{\ACM@linecountL}%
     \fancyfoot[RO,LE]{\if@ACM@printfolios\small\thepage\fi}%
-    \fancyfoot[RE,LO]{\footnotesize Manuscript submitted to ACM}%
+    \if@ACM@nonacm\else%
+      \fancyfoot[RE,LO]{\footnotesize Manuscript submitted to ACM}%
+    \fi%
   \or % acmsmall
-    \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
-    \@acmNumber, Article \@acmArticle.  Publication date:
-    \@acmPubDate.}%
+    \if@ACM@nonacm\else%
+      \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
+      \@acmNumber, Article \@acmArticle.  Publication date:
+      \@acmPubDate.}%
+    \fi%
     \fancyhead[LE]{\ACM@linecountL\@folioblob}%
     \fancyhead[LO]{\ACM@linecountL}%
     \fancyhead[RO]{\@folioblob}%
     \fancyheadoffset[RO,LE]{0.6\@folio@wd}%
   \or % acmlarge
-    \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
-    \@acmNumber, Article \@acmArticle.  Publication date:
-    \@acmPubDate.}%
+    \if@ACM@nonacm\else%
+      \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
+      \@acmNumber, Article \@acmArticle.  Publication date:
+      \@acmPubDate.}%
+    \fi%
     \fancyhead[RO]{\@folioblob}%
     \fancyhead[LE]{\ACM@linecountL\@folioblob}%
     \fancyhead[LO]{\ACM@linecountL}%
     \fancyheadoffset[RO,LE]{1.4\@folio@wd}%
   \or % acmtog
-    \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
-    \@acmNumber, Article \@acmArticle.  Publication date:
-    \@acmPubDate.}%
+    \if@ACM@nonacm\else%
+      \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
+      \@acmNumber, Article \@acmArticle.  Publication date:
+      \@acmPubDate.}%
+    \fi%
     \fancyhead[L]{\ACM@linecountL}%
     \fancyhead[R]{\ACM@linecountR}%
   \else % Conference proceedings
@@ -5878,7 +5928,9 @@ Computing Machinery]
   \if@ACM@timestamp
     \ifnum\ACM@format@nr=0\relax % Manuscript
     \fancyfoot[LO,RE]{\ACM@timestamp\quad
-      \footnotesize Manuscript submitted to ACM}
+      \if@ACM@nonacm\else
+        \footnotesize Manuscript submitted to ACM
+      \fi}
     \else
     \fancyfoot[LO,RE]{\ACM@timestamp}
     \fi

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -5741,6 +5741,13 @@ Computing Machinery]
   \fancyhf{}%
   \renewcommand{\headrulewidth}{\z@}%
   \renewcommand{\footrulewidth}{\z@}%
+  \def\@acmArticlePage{%
+    \ifx\@acmArticle\empty%
+      \if@ACM@printfolios\thepage\fi%
+    \else%
+      \@acmArticle\if@ACM@printfolios:\thepage\fi%
+    \fi%
+  }
   \ifcase\ACM@format@nr
   \relax % manuscript
     \fancyhead[LE]{\ACM@linecountL\if@ACM@printfolios\thepage\fi}%
@@ -5751,8 +5758,8 @@ Computing Machinery]
       \fancyfoot[RO,LE]{\footnotesize Manuscript submitted to ACM}
     \fi%
   \or % acmsmall
-    \fancyhead[LE]{\ACM@linecountL\@headfootfont\@acmArticle\if@ACM@printfolios:\thepage\fi}%
-    \fancyhead[RO]{\@headfootfont\@acmArticle\if@ACM@printfolios:\thepage\fi}%
+    \fancyhead[LE]{\ACM@linecountL\@headfootfont\@acmArticlePage}%
+    \fancyhead[RO]{\@headfootfont\@acmArticlePage}%
     \fancyhead[RE]{\@headfootfont\@shortauthors}%
     \fancyhead[LO]{\ACM@linecountL\@headfootfont\shorttitle}%
     \if@ACM@nonacm\else%
@@ -5761,21 +5768,21 @@ Computing Machinery]
     \fi%
   \or % acmlarge
     \fancyhead[LE]{\ACM@linecountL\@headfootfont
-      \@acmArticle\if@ACM@printfolios:\thepage\fi\quad\textbullet\quad\@shortauthors}%
+      \@acmArticlePage\quad\textbullet\quad\@shortauthors}%
     \fancyhead[LO]{\ACM@linecountL}%
     \fancyhead[RO]{\@headfootfont
-      \shorttitle\quad\textbullet\quad\@acmArticle\if@ACM@printfolios:\thepage\fi}%
+      \shorttitle\quad\textbullet\quad\@acmArticlePage}%
     \if@ACM@nonacm\else%
       \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
       \@acmNumber, Article \@acmArticle.  Publication date: \@acmPubDate.}%
     \fi%
   \or % acmtog
     \fancyhead[LE]{\ACM@linecountL\@headfootfont
-      \@acmArticle\if@ACM@printfolios:\thepage\fi\quad\textbullet\quad\@shortauthors}%
+      \@acmArticlePage\quad\textbullet\quad\@shortauthors}%
     \fancyhead[LO]{\ACM@linecountL}%
     \fancyhead[RE]{\ACM@linecountR}%
     \fancyhead[RO]{\@headfootfont
-      \shorttitle\quad\textbullet\quad\@acmArticle\if@ACM@printfolios:\thepage\fi\ACM@linecountR}%
+      \shorttitle\quad\textbullet\quad\@acmArticlePage\ACM@linecountR}%
     \if@ACM@nonacm\else%
       \fancyfoot[RO,LE]{\footnotesize \@journalNameShort, Vol. \@acmVolume, No.
       \@acmNumber, Article \@acmArticle.  Publication date: \@acmPubDate.}%

--- a/acmart.dtx
+++ b/acmart.dtx
@@ -5523,7 +5523,7 @@ Computing Machinery]
   \def\@pages@word{\ifnum\getrefnumber{TotPages}=1\relax page\else pages\fi}%
   \def\footnotemark{}%
   \def\\{\unskip{} \ignorespaces}%
-  \def\footnote{\ClassError{\@classname}{Please do note use footnotes
+  \def\footnote{\ClassError{\@classname}{Please do not use footnotes
       inside a \string\title{} or \string\author{} command! Use
       \string\titlenote{} or \string\authornote{} instead!}}%
   \def\@article@string{\ifx\@acmArticle\@empty{\ }\else,


### PR DESCRIPTION
The 'nonacm' option is meant to be used for documents that were
prepared for an ACM submission using the acmart class and one of the
formats, but are not accepted for publication. They wish to make the
document available on their webpage, circulate it to colleagues, but
keeping the acmart documentclass includes a lot of
ACM-publication-specific content that is irrelevant to
them.

Currently their only choice, if they want a version of their work that
displays nicely, is to change their documentclass to another LaTeX
class, which is tedious as it involves reflows etc., but also
rewriting the author, affiliation, institute information to use
different macros. They may later decide to resubmit the work to
another ACM venue, and have to change this all over again.

The new 'nonacm' option disables the ACM-venues-specific content in
the acmart output (name of journal or conference, copyright
statements, DOI...) to produce a standalone, independent document that
authors can release.
(The 'manuscript' or 'authorversion' are simliar but do not solve this
use-case: this is not an "author version of an ACM publication" or
a "manuscript submitted to the ACM".)

This option is complementary to the choice of a format option
(acmsmall, acmlarge...), it is not an extra format. Setting 'nonacm'
should respect the existing format (although of course the page breaks
may be placed differently). For example, most headers and footers set
by the format are preserved, only the ones that reference a specific
journal/conference are omitted.

By default, the 'nonacm' option sets 'printacmref=false', so the "ACM
Reference Format" paragraph is not included. Users can explicitly
use `\settopmatter{printacmref=true}` to re-enable it.

The present patchset also contains two independent changes:
- a minor typo fix
- a small fix to avoid the problem of having ":3" show up as the right header (on page 3)
  when the \acmArticle macro is not set, so that the article number is empty. With the fix,
  the header is just "3" as expected.