### PR TITLE
Fix #296: Avoid Hyperref warnings with TeXLive 2018

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -2575,7 +2575,9 @@ Computing Machinery]
       filecolor=ACMDarkBlue}
     \else
     \hypersetup{hidelinks}
-  \fi}
+  \fi
+  \hypersetup{pdflang={English},
+    pdfdisplaydoctitle}}
 %    \end{macrocode}
 %
 % Bibliography mangling.
@@ -4768,8 +4770,6 @@ Computing Machinery]
      \@mkbibcitation
   \fi
   \hypersetup{%
-    pdflang={English},
-    pdfdisplaydoctitle,
     pdfauthor={\authors},
     pdftitle={\@title},
     pdfsubject={\@concepts},


### PR DESCRIPTION
Fix #296.

Options `pdflang` and `pdfdisplaydoctitle` are disabled `AtBeginDocument`, but `acmart`
sets them in `\maketitle` which is run too late.

Since those options do not depend on the title, set them earlier
unconditionally removes the warning. Using AtEndPreamble for this is just
defensive coding and might be unnecessary; both limited testing and the history
entry below from `acmart.dtx` suggest this is indeed probably unnecessary:

```latex
\changes{v1.46}{2017/08/25}{Delayed hypersetup since journal options
may change screen mode}
```