### PR TITLE
Fix #294: invoke pdfglyphtounicode correctly

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -2857,9 +2857,9 @@ Computing Machinery]
 \pdfglyphtounicode{f_f_i}{FB03}
 \pdfglyphtounicode{f_f_l}{FB04}
 \pdfglyphtounicode{f_i}{FB01}
-\pdfglyphtounicode{t_t}{00740074}
-\pdfglyphtounicode{f_t}{00660074}
-\pdfglyphtounicode{T_h}{00540068}
+\pdfglyphtounicode{t_t}{0074 0074}
+\pdfglyphtounicode{f_t}{0066 0074}
+\pdfglyphtounicode{T_h}{0054 0068}
 \pdfgentounicode=1
 \fi
 \RequirePackage{cmap}


### PR DESCRIPTION
This avoids the warnings, tho I couldn't reproduce #167 to confirm. Still, this
should work according to the explanation in
https://github.com/borisveytsman/acmart/issues/294#issuecomment-405108878.

Thanks @kberry for the clarification!