### PR TITLE
Add macro to customise the name of the "Acknowledgements" section.

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -6471,6 +6471,14 @@ Computing Machinery]
 %\subsection{Acknowledgments}
 %\label{sec:acks}
 %
+% \begin{macro}{\acksname}
+% \changes{v1.55}{2018/10/16}{Added macro (Philip Quinn)}
+%    \begin{macrocode}
+\newcommand\acksname{Acknowledgments}
+%    \end{macrocode}
+%
+% \end{macro}
+%
 % \begin{macro}{\acks}
 % \changes{v1.19}{2016/07/28}{Include 'Acknowledgements' in PDF bookmarks
 % (Matthew Fluet)}
@@ -6479,8 +6487,8 @@ Computing Machinery]
 %    \begin{macrocode}
 \specialcomment{acks}{%
   \begingroup
-  \section*{Acknowledgments}
-  \phantomsection\addcontentsline{toc}{section}{Acknowledgments}
+  \section*{\acksname}
+  \phantomsection\addcontentsline{toc}{section}{\acksname}
 }{%
   \endgroup
 }


### PR DESCRIPTION
Both "Acknowledg**e**ments" and "Acknowledgments" are used, and such a command is consistent with those like `\abstractname`.