### PR TITLE
Fix typo, convert tabs to spaces, remove extra newline.

### DIFF
--- a/README
+++ b/README
@@ -187,7 +187,7 @@ Version 1.52    Another rewording of licenses
 
 Version 1.53    New journals: PACMCGIT, TIOT, TDSCI
 
-Version 1.54    New option: 'noacm' (Gabriel Scherer)
+Version 1.54    New option: 'nonacm' (Gabriel Scherer)
                 Deleted indent for subsubsection (suggested by Ross Moore)
                 Suppressed some obscurious warning in BibTeX processing
                 Suppressed hyperrerf warnings (Paolo G. Giarrusso)
@@ -197,18 +197,17 @@ Version 1.54    New option: 'noacm' (Gabriel Scherer)
                 Bug fixes
 
 Version 1.55    Bug fixes
-		Font changes for SIGCHI table captions
-
+                Font changes for SIGCHI table captions
 
 Version 1.56    Bug fixes
-		Added \flushbottom to two column formats (Philip Quinn)
-		The final punctuation for the list of concepts
-		is now period instead of semilcolon (Philip Quinn)
-		New command \Description to describe images for visually
-		impaired users.
+                Added \flushbottom to two column formats (Philip Quinn)
+                The final punctuation for the list of concepts
+                is now period instead of semilcolon (Philip Quinn)
+                New command \Description to describe images for visually
+                impaired users.
 
 Version 1.57    Change of \baselinestretch now produces an error
-		Booktabs is now always loaded
-		Added option `balance' to balance last page in two-column mode
-		E-mail is no longer split in addresses
-		New samples (Stephen Spencer)
+                Booktabs is now always loaded
+                Added option `balance' to balance last page in two-column mode
+                E-mail is no longer split in addresses
+                New samples (Stephen Spencer)


### PR DESCRIPTION
This will cleanup the formatting of `README`, and fixes a typo for the `nonacm` option.