### PR TITLE
Ignore spaces after \Description.

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -3066,7 +3066,7 @@ Computing Machinery]
 % \changes{v1.56}{2018/11/11}{Added macro}
 % The Description macro right now just sets switches
 %    \begin{macrocode}
-\newcommand\Description[2][]{\global\@Description@presenttrue}
+\newcommand\Description[2][]{\global\@Description@presenttrue\ignorespaces}
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
When \Description is placed between a figure's image and its caption, it inadvertently creates a new paragraph.

Fixes #333