### PR TITLE
Enable `screen` option to match description

### DIFF
--- a/samples/sample-sigconf.tex
+++ b/samples/sample-sigconf.tex
@@ -1,6 +1,6 @@
 %
 % The first command in your LaTeX source must be the \documentclass command.
-\documentclass[sigconf]{acmart}
+\documentclass[sigconf,screen]{acmart}
 
 %
 % \BibTeX command to typeset BibTeX logo in the docs


### PR DESCRIPTION
Match the following description.
> This document uses the following string as the first command in the source file: \verb|\documentclass[sigconf,screen]{acmart}|.