### PR TITLE
Replace a bashism with portable shell code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ acmguide.pdf: $(PACKAGE).dtx $(PACKAGE).cls
 ALLSAMPLES:
 	cd samples; pdflatex samples.ins; cd ..
 	for texfile in samples/*.tex; do \
-		pdffile=$${texfile/.tex/.pdf}; \
+		pdffile=$${texfile%.tex}.pdf; \
 		${MAKE} $$pdffile; \
 	done
 


### PR DESCRIPTION
This patch is needed to be able to run `make` on my (and I presume others) Ubuntu 19.04.  This is since GNU `make` defaults to `/bin/sh` not `/bin/bash` (see
https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html).