### PR TITLE
Add a `.PHONY` target to the `Makefile` for non-file targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,3 +100,5 @@ zip:  all clean
 
 documents.zip: all docclean
 	zip -r $@ acmart.pdf acmguide.pdf samples *.cls ACM-Reference-Format.*
+
+.PHONY: all ALLSAMPLES docclean clean distclean archive zip


### PR DESCRIPTION
This PR simply adds a `.PHONY` target to the `Makefile` for `make` targets that are not files.  See https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html for why these are important.