### PR TITLE
Rewrap lines in one of the permission blocks

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -4826,10 +4826,10 @@
    source.
   \or % usgovmixed
    ACM acknowledges that this contribution was authored or co-authored
-   by an employee, contractor, or affiliate of the United States government. As such,
-   the United States government retains a nonexclusive, royalty-free right to
-   publish or reproduce this article, or to allow others to do so, for
-   government purposes only.
+   by an employee, contractor, or affiliate of the United States
+   government. As such, the United States government retains a
+   nonexclusive, royalty-free right to publish or reproduce this
+   article, or to allow others to do so, for government purposes only.
   \or % cagov
    This article was authored by employees of the Government of Canada.
    As such, the Canadian government retains all interest in the


### PR DESCRIPTION
All of the other permission blocks are wrapped to column 72 (75?), so this PR changes this block to also be wrapped at column 72.

This is a whitespace-only change.
