### PR TITLE
harmonizing some bib entry capitalization

### DIFF
--- a/samples/sample-base.bib
+++ b/samples/sample-base.bib
@@ -665,7 +665,7 @@ year = {2003},
   note =         "",
 }
 
-@article{Rous08,
+@article{rous08,
   author =       "Bernard Rous",
   year =         "2008",
   title =        "The Enabling of Digital Libraries",
@@ -1434,7 +1434,7 @@ month = jul,
 year = 1984,
 pages = "380--401"}
 
-@book{lamport:latex,
+@book{Lamport:LaTeX,
 author = "Leslie Lamport",
 title = "\it {\LaTeX}: A Document Preparation System",
 publisher = "Addison-Wesley",


### PR DESCRIPTION
The capitalization of at least these two entries differ from their usage in the sample documents. On my system and with my slight reconfiguration, this caused warnings when compiling these documents. 

This should correct that without affecting the rest. 