### PR TITLE
removing an extraneous paren

### DIFF
--- a/samples/sample-base.bib
+++ b/samples/sample-base.bib
@@ -874,7 +874,7 @@ year = {2003},
 }
 
 % div book
-@book{Mullender:1993:DS(:302430,
+@book{Mullender:1993:DS:302430,
  editor = {Mullender, Sape},
  title = {Distributed systems (2nd Ed.)},
  year = {1993},


### PR DESCRIPTION
The Mullender "Distributed Systems" bib entry seemed to have an extraneous left paren in it. On my system and with my slight reconfiguration, this caused an error. Eliminating that paren should correct the issue without other impact.