### PR TITLE
adding detokenize

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -4058,7 +4058,7 @@
 %   Adding an author to the list of authors and addresses
 %    \begin{macrocode}
 \renewcommand\author[2][]{%
-  \IfSubStr{#2}{,}{\ClassWarning{\@classname}{Do not put several
+  \IfSubStr{\detokenize{#2}}{,}{\ClassWarning{\@classname}{Do not put several
       authors in the same \string\author\space macro!}}{}%
   \global\advance\num@authors by 1\relax
   \if@insideauthorgroup\else


### PR DESCRIPTION
\IfSubStr assumes that the argument is of the type \xstring which is not necessarily the case 

How to reproduce the bug:

Use \author{John \textcircled{r}} 

(\textcircled{r} is a new standard proposed by AEA for random author ordering. )

The following error is observed:

```

\UseTextAccent ...up \@firstofone \let \@curr@enc

\cf@encoding \@use@text@en...
```

The pull request adds detokenize so that special characters can be properly parsed. 

