### PR TITLE
Add \country to American example authors

### DIFF
--- a/samples/samples.dtx
+++ b/samples/samples.dtx
@@ -101,6 +101,7 @@
   \streetaddress{P.O. Box 1212}
   \city{Dublin}
   \state{Ohio}
+  \country{USA}
   \postcode{43017-6221}
 }
 
@@ -141,6 +142,7 @@
   \streetaddress{8600 Datapoint Drive}
   \city{San Antonio}
   \state{Texas}
+  \country{USA}
   \postcode{78229}}
 \email{cpalmer@prl.com}
 


### PR DESCRIPTION
The example currently omits the use of \country for the American authors. This suggests that 'USA' is somehow a default and only authors from other countries should add this. It would be more sensible to treat authors from all countries in the same way.