### PR TITLE
Add package name inconsolata to the missing zi4.sty error

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -3175,7 +3175,7 @@
     have the libertine package installed.  Please upgrade your
     TeX}\@ACM@newfontsfalse}
 \IfFileExists{zi4.sty}{}{\ClassWarning{\@classname}{You do not
-    have the zi4 package installed.  Please upgrade your
+    have the inconsolata (zi4.sty) package installed.  Please upgrade your
     TeX}\@ACM@newfontsfalse}
 \IfFileExists{newtxmath.sty}{}{\ClassWarning{\@classname}{You do not
     have the newtxmath package installed.  Please upgrade your


### PR DESCRIPTION
This PR changes the error message from

```
You do not have the zi4 package installed. Please upgrade your TeX
```

to

```
You do not have the inconsolata (zi4.sty) package installed. Please upgrade your TeX
```

When encountering this error I happily tried to install the `zi4` package to find that there is none.
`zi4.sty` belongs to the inconsolata these days.