### PR TITLE
Fixes #402.

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -3205,6 +3205,7 @@
 %    \begin{macrocode}
 \if@ACM@newfonts
   \RequirePackage[T1]{fontenc}
+  \RequirePackage[libertine]{newtxmath}
   \ifxetex
     \RequirePackage[tt=false]{libertine}
     \setmonofont[StylisticSet=3]{inconsolata}
@@ -3217,7 +3218,6 @@
        \RequirePackage[varqu]{zi4}
     \fi
   \fi
-  \RequirePackage[libertine]{newtxmath}
 \fi
 %    \end{macrocode}
 %


### PR DESCRIPTION
According to section 5 of the documentation for `newtx`, "`newtxmath`
works with both [`xelatex` and `lualatex`], but requires a very specific
loading order and choice of options."

I haven't investigated carefully, but it seems that loading `newtxmath`
before `libertine` solves the issue.