### PR TITLE
Remove redundant loading of `iftex`.

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -3157,7 +3157,6 @@
 %
 % The code below is by Ross Moore.
 %    \begin{macrocode}
-\RequirePackage{iftex}
 \ifPDFTeX
 \input{glyphtounicode}
 \pdfglyphtounicode{f_f}{FB00}


### PR DESCRIPTION
There is already a `\RequirePackage{iftex}` at line 2040 of `acmart.dtx`
so we do not need another one here.