### PR TITLE
Do not load `cmap.sty` in `xelatex` or `lualatex`

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -3168,8 +3168,8 @@
 \pdfglyphtounicode{f_t}{0066 0074}
 \pdfglyphtounicode{T_h}{0054 0068}
 \pdfgentounicode=1
-\fi
 \RequirePackage{cmap}
+\fi
 %    \end{macrocode}
 %
 %


### PR DESCRIPTION
Compiling the following document with `xelatex` or `lualatex`
produces the following warning.

Document:

```
\documentclass{acmart}
\begin{document}
\end{document}
```

Warning:

```
(/usr/share/texlive/texmf-dist/tex/latex/cmap/cmap.sty

Package cmap Warning: pdftex not detected - exiting.

)
```

As far as I can tell `cmap.sty` should be used with only `pdflatex`
and not `xelatex` or `lualatex`.

This commit simply moves `\RequirePackage{cmap}` under a `\ifPDFTeX` test.