### PR TITLE
Fix #410: Wrong math fonts in non-unicode compilers (after #403)

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -3217,17 +3217,19 @@
 %    \begin{macrocode}
 \if@ACM@newfonts
   \RequirePackage[T1]{fontenc}
-  \RequirePackage[libertine]{newtxmath}
   \ifxetex
+    \RequirePackage[libertine]{newtxmath}
     \RequirePackage[tt=false]{libertine}
     \setmonofont[StylisticSet=3]{inconsolata}
   \else
     \ifluatex
+      \RequirePackage[libertine]{newtxmath}
       \RequirePackage[tt=false]{libertine}
       \setmonofont[StylisticSet=3]{inconsolata}
     \else
        \RequirePackage[tt=false, type1=true]{libertine}
        \RequirePackage[varqu]{zi4}
+       \RequirePackage[libertine]{newtxmath}
     \fi
   \fi
 \fi


### PR DESCRIPTION
This commit fixes the breakage of fonts when using a standard
non-unicode compiler, such as `pdflatex`, after PR #403.

As mentioned by @isaacsb, in #410 one solution (the one applied here)
is to load newtxmath before the text fonts in xelatex/lualatex
but after them otherwise.