### PR TITLE
Documenting a package load-order subtlety

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -3217,6 +3217,10 @@
 %    \begin{macrocode}
 \if@ACM@newfonts
   \RequirePackage[T1]{fontenc}
+  % Note that the order in which packages are loaded matters,
+  % and the correct order depends on the LaTeX engine used.
+  % See https://github.com/borisveytsman/acmart/issues/402
+  % and https://github.com/borisveytsman/acmart/issues/410
   \ifxetex
     \RequirePackage[libertine]{newtxmath}
     \RequirePackage[tt=false]{libertine}


### PR DESCRIPTION
Since issues #402 and #410 are so subtle and easy to overlook and since future editors of the code might not realize the importance of the load orders of those particular packages, this pull request adds a comment to the code explaining this so future editors of that part of the code are sure to see it.