### PR TITLE
Autogenerated "Authors' addresses: ..." and authors with multiple affiliations

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -6206,12 +6206,13 @@
   \def\streetaddress##1{\unskip, ##1}%
   \def\postcode##1{\unskip, ##1}%
   \def\position##1{\unskip\ignorespaces}%
-  \def\institution##1{\unskip, ##1}%
+  \gdef\@ACM@institution@separator{, }%
+  \def\institution##1{\unskip\@ACM@institution@separator ##1\gdef\@ACM@institution@separator{ and }}%
   \def\city##1{\unskip, ##1}%
   \def\state##1{\unskip, ##1}%
   \renewcommand\department[2][0]{\unskip\@addpunct, ##2}%
   \def\country##1{\unskip, ##1}%
-  \def\and{\unskip; }%
+  \def\and{\unskip; \gdef\@ACM@institution@separator{, }}%
   \def\@author##1{##1}%
   \def\email##1##2{\unskip, \nolinkurl{##2}}%
   \addresses


### PR DESCRIPTION
If I understood the current version of the guide document right, an author with multiple affiliations is supposed to be entered as...
```
\author{a}
\affiliation{\institution{i1}\city{c1}}
\affiliation{\institution{i2}\city{c2}}
```
For journals, this produces an "Authors' addresses: " line that reads something like...
```
a, i1, c1, i2, c2;
```
...which could be hard to parse visually.

Aside from asking an author to manually specify the complete `\authorsaddresses` line there is probably no easy solution for complex cases - but maybe simply adding an "`and`" in-between multiple institutions of a single author...
```
a, i1, c1 and i2, c2;
```
...can take autogeneration a little step further.

I am attaching a (highly simplistic) proof of concept patch.