### PR TITLE
When printing the 'note' field, add the period outside \shownote

### DIFF
--- a/ACM-Reference-Format.bst
+++ b/ACM-Reference-Format.bst
@@ -692,7 +692,7 @@ FUNCTION { output.note } % UTAH
 { % return with stack empty
   note empty.or.unknown
     { }
-    { "\shownote{" note add.period$ * "}" * writeln }
+    { "\shownote{" note * "}" add.period$ * writeln }
   if$
 }
 
@@ -700,7 +700,7 @@ FUNCTION { output.note.check } % UTAH
 { % return with stack empty
   note empty.or.unknown
     { "empty note in " cite$ * warning$ }
-    { "\shownote{" note add.period$ * "}" * writeln }
+    { "\shownote{" note * "}" add.period$ * writeln }
   if$
 }
 


### PR DESCRIPTION
When printing 'note' fields, the period should go after the closing brace of '\shownote'.

I believe this was just a typo. Elsewhere the added period is outside the respective command.