### PR TITLE
Consistent spacing of [n.d.]

### DIFF
--- a/ACM-Reference-Format.bst
+++ b/ACM-Reference-Format.bst
@@ -487,12 +487,12 @@ FUNCTION { format.articleno }
 }
 
 FUNCTION { format.year }
-{ % push year string or "[n.\,d.]" onto output stack
+{ % push year string or "[n.d.]" onto output stack
   %% Because year is a mandatory field, we always force SOMETHING
   %% to be output
   "\bibinfo{year}{"
   year empty.or.unknown
-    { "[n.\,d.]" }
+    { "[n.d.]" }
     { year }
   if$
   *  "}" *


### PR DESCRIPTION
I personally prefer a little space after the abbreviating dot,
but to make it consistent with the rest of the style, I recommend to remove `\,` in `[n.\,d.]`.

Other occurrences of "n.d.":
- In `output.year.check`: https://github.com/borisveytsman/acmart/blob/c025ac254be05906ccafd7155659b8a552732075/ACM-Reference-Format.bst#L773
- In `calc.basic.label`: https://github.com/borisveytsman/acmart/blob/c025ac254be05906ccafd7155659b8a552732075/ACM-Reference-Format.bst#L1992
- In `calc.label`: https://github.com/borisveytsman/acmart/blob/c025ac254be05906ccafd7155659b8a552732075/ACM-Reference-Format.bst#L2040

Other abbreviation without spacing "Ph.D.":
- In `phdthesis`: https://github.com/borisveytsman/acmart/blob/c025ac254be05906ccafd7155659b8a552732075/ACM-Reference-Format.bst#L2432