### PR TITLE
Fix a typo in acmart.dtx

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -643,7 +643,7 @@
 %
 % The fields \cs{institution}, \cs{city} and \cs{country} are
 % mandatory.  If they are not provided, an error or a warning  is
-% issued. Currently the absence of \cs{country} produces and error;
+% issued. Currently the absence of \cs{country} produces an error;
 % ACM may change this in the future.
 %
 %


### PR DESCRIPTION
"and error" -> "an error", simple fix. 