### PR TITLE
Suppress URL if DOI is existing using BibLaTex

### DIFF
--- a/ACM-Reference-Format.bbx
+++ b/ACM-Reference-Format.bbx
@@ -263,7 +263,18 @@
   \usebibmacro{issue}%
   \newunit}
 
-
+\renewbibmacro*{doi+eprint+url}{%
+  \iftoggle{bbx:url}
+    {\iffieldundef{doi}{\usebibmacro{url+urldate}}{}}
+    {}%
+  \newunit\newblock
+  \iftoggle{bbx:eprint}
+    {\usebibmacro{eprint}}
+    {}%
+  \newunit\newblock
+  \iftoggle{bbx:doi}
+    {\printfield{doi}}
+    {}}
 
 
 %%% Definitions for drivers (alphabetical)


### PR DESCRIPTION
Using BibLaTex with natbib=false the URL are not suppressed for an existing DOI.
This fixes the behavior but does not yet introduce the new feature from #453