### PR TITLE
#455 \anon command added

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -299,7 +299,7 @@
 %     \normalfont Value & Meaning\\
 %     \midrule
 %   manuscript & A manuscript. This is the default. \\
-%   acmsmall & Small single-column format.  Used for CIE, CSUR, 
+%   acmsmall & Small single-column format.  Used for CIE, CSUR,
 %            DLT, FAC, JACM, JDIQ, JEA, JERIC,
 %            JETC, PACMCGIT, PACMHCI, PACMPL, TAAS, TACCESS, TACO,
 %            TALG, TALLIP (formerly TALIP), TCPS, TDS,
@@ -325,7 +325,7 @@
 % SIGCHI conferences now use |sigconf| format for their publications.
 % If a file uses |sigchi| format, a warning is issued, and the format
 % is automatically switched to |sigconf|.  Format |sigchi-a| can be
-% used for non-ACM documents only (see Section~\ref{sec:sigchi-a}).  
+% used for non-ACM documents only (see Section~\ref{sec:sigchi-a}).
 %
 % There are several Boolean options that can take |true| or |false|
 % values.  They are listed in Table~\ref{tab:opts_bool}.  The words
@@ -340,7 +340,7 @@
 %
 % Two samples in the |samples| directory, |manuscript| and
 % |acmsmall-submission|, show manuscripts formatted for submission to
-% ACM.  
+% ACM.
 %
 % The default for the option |screen| depends on the publication.  At
 % present it is |false| for all publications \emph{but} PACM, since
@@ -414,7 +414,7 @@
 %                        mode\\
 %     pbalance & false & Whether to balance the last page in two column
 %                        mode using pbalance package\\
-%     urlbreakonhyphens & true & Whether to break urls on hyphens\\ 
+%     urlbreakonhyphens & true & Whether to break urls on hyphens\\
 %     \bottomrule
 %   \end{tabularx}
 % \end{table}
@@ -492,7 +492,7 @@
 % formatting.  In the samples directory there is a file
 % |sample-acmsmall-conf.tex| with the example of this usage.
 %
-% 
+%
 %
 % \DescribeMacro{\editor}%
 % In most cases, conference proceedings are edited.  You can use the
@@ -749,7 +749,7 @@
 % 123456 Helm, Germany
 % \end{verbatim}
 %
-% Note that you should \emph{not} use this option for journals.  
+% Note that you should \emph{not} use this option for journals.
 %
 % It is expected that these commands are inserted by the author of the
 % manuscript.
@@ -782,7 +782,7 @@
 % \end{verbatim}
 % You can \emph{suppress} printing authors' addresses by setting them
 % to an empty string:  |\authorsaddresses{}|.  Please note that
-% authors' addresses are mandatory for journal articles.  
+% authors' addresses are mandatory for journal articles.
 %
 % \DescribeMacro{\titlenote}%
 % \DescribeMacro{\subtitlenote}%
@@ -976,7 +976,7 @@
 %
 % CCS Concepts and user-defined keywords are required for all articles
 % over two pages in length, and are optional for one- and two-page
-% articles (or abstracts). 
+% articles (or abstracts).
 %
 % \DescribeMacro{\setcopyright}
 % There are several possibilities for the copyright of the papers
@@ -987,7 +987,7 @@
 % copyright status of the paper, for example,
 % \verb|\setcopyright{acmcopyright}|.  The possible values for this
 % command are listed in Table~\ref{tab:setcopyright}.  This command
-% must be placed in the preamble, before |\begin{document}|.  
+% must be placed in the preamble, before |\begin{document}|.
 %
 % \begin{table}
 %   \centering
@@ -1102,7 +1102,7 @@
 % The parameter |printacmref| specifies whether to print the ACM
 % bibliographic entry (default), or not.  Note that this entry is
 % required for all articles over one page in length, and is optional
-% for one-page articles (abstracts). 
+% for one-page articles (abstracts).
 %
 % \begin{table}
 %   \centering
@@ -1269,7 +1269,7 @@
 % \end{figure}
 % \end{verbatim}
 % At present the lack of descriptions generates a warning at
-% compilation.  
+% compilation.
 %
 %\subsection{Theorems}
 %\label{sec:ug_theorems}
@@ -1459,7 +1459,7 @@
 % \end{verbatim}
 % Normally the printing of URL is suppressed if DOI is present.
 % However, there is a special field \path{distinctURL}.  If it is
-% present and is not zero, URL is printed even if DOI is present. 
+% present and is not zero, URL is printed even if DOI is present.
 %
 %
 % The style supports the arXiv-recommended fields \path{eprint} and
@@ -1482,7 +1482,7 @@
 %  lastaccessed = "March 2, 2005",
 % }
 % \end{verbatim}
-% Entry types \path{artifactsoftware}, \path{artifactdataset} 
+% Entry types \path{artifactsoftware}, \path{artifactdataset}
 % (with synonyms \path{software} and \path{dataset}) can be used to
 % cite software artifacts and datasets, for example,
 % \begin{verbatim}
@@ -1503,11 +1503,11 @@
 %  lastaccessed = {May 27, 2019}
 % }
 % \end{verbatim}
-% 
+%
 %
 % For these entry types you can use the \path{lastaccessed} field to add
 % the access date for the URL.
-% 
+%
 %
 %
 % There are two ways to enter video or audio sources in the
@@ -1600,8 +1600,8 @@
 % The current bst style defines a number of macros for common journal
 % names.  In particular, all journals listed in Table~\ref{tab:pubs}
 % are includes, so you can use strings like |journal = taccess| for
-% \emph{ACM Transactions on Accessible Computing}.  
-% 
+% \emph{ACM Transactions on Accessible Computing}.
+%
 %
 %\subsection{Colors}
 %\label{sec:ug_colors}
@@ -1711,7 +1711,7 @@
 % The script |texcount| provides a report of word count in the
 % document.
 %
-% 
+%
 %
 %
 %\subsection{Disabled or forbidden commands}
@@ -1782,7 +1782,7 @@
 % \begin{verbatim}
 % \AtBeginMaketitle{\acmPrice{125.00}}
 % \end{verbatim}
-% 
+%
 %
 %\subsection{Currently supported publications}
 %\label{sec:pubs}
@@ -1806,7 +1806,7 @@
 % \endfoot
 %     CIE & ACM Computers in Entertainment \\
 %     CSUR & ACM Computing Surveys\\
-%     DLT & Distributed Ledger Technologies: Research and Practice\\ 
+%     DLT & Distributed Ledger Technologies: Research and Practice\\
 %     DGOV & Digital Government: Research and Practice \\
 %     DTRAP &  Digital Threats: Research and Practice\\
 %     FAC & Formal Aspects of Computing \\
@@ -1876,7 +1876,7 @@
 %
 % Besides the publications listed in Table~\ref{tab:pubs}, there is a
 % special ``publication'' type FACMP, a forthcoming ACM publication,
-% reserved for new journals which are not assigned an ISSN yet.  
+% reserved for new journals which are not assigned an ISSN yet.
 %
 %
 %\subsection{A note about \texttt{sigchi-a} format}
@@ -1892,7 +1892,7 @@
 % \documentclass[sigchi-a, nonacm]{acmart}
 % \end{verbatim}
 %
-% 
+%
 %
 % \DescribeEnv{sidebar}%
 % \DescribeEnv{marginfigure}%
@@ -1909,7 +1909,7 @@
 % The environments |figure| and |table| produce figures and tables
 % with the width of the text column.  The environments |figure*| and
 % |table*| produce ``wide'' figures and tables, which take a large
-% part of the margin.  
+% part of the margin.
 %
 % The horizontal sizes of figures are:
 % \begin{enumerate}
@@ -1917,8 +1917,8 @@
 % \item |marginfigure|: \cs{marginparwidth},
 % \item |figure*|: \cs{fulltextwidth}.
 % \end{enumerate}
-% 
-% 
+%
+%
 %
 % \StopEventually{
 % \clearpage
@@ -2030,11 +2030,11 @@
 % \changes{1.57}{2018/12/16}{Booktabs package is now the default}
 % \changes{1.58}{2019/02/09}{Changes in samples (Enrico Gregorio)}
 % \changes{1.58}{2019/03/29}{New journal: HEALTH.  TDS is renamed to
-% TDSCI} 
+% TDSCI}
 % \changes{1.60}{2019/04/22}{New option: urlbreakonhyphens}
 % \changes{1.62}{2019/07/31}{New journal: TELO}
 % \changes{1.63}{2019/08/04}{New journal: TQUANT}
-% \changes{1.63}{2019/08/04}{New journal: FACMP} 
+% \changes{1.63}{2019/08/04}{New journal: FACMP}
 % \changes{1.63a}{2019/08/05}{Move: TQUANT to TQC}
 % \changes{1.64}{2019/08/17}{Putting abstract after \cs{maketitle} now
 % causes an error}
@@ -2104,8 +2104,8 @@
 %    \begin{macrocode}
 \RequirePackage{iftex}
 %    \end{macrocode}
-% 
-% 
+%
+%
 %
 % \begin{macro}{format}
 %   The possible formats
@@ -2147,7 +2147,7 @@
 % \end{macro}
 %
 % \begin{macro}{\if@ACM@urlbreakonhyphens}
-% \changes{1.60}{2019/04/22}{introduced macro} 
+% \changes{1.60}{2019/04/22}{introduced macro}
 %    \begin{macrocode}
 \define@boolkey+{acmart.cls}[@ACM@]{urlbreakonhyphens}[true]{%
   \if@ACM@urlbreakonhyphens
@@ -2241,7 +2241,7 @@
     false}}
 \ExecuteOptionsX{balance}
 %    \end{macrocode}
-% 
+%
 % \end{macro}
 %
 %
@@ -2254,9 +2254,9 @@
     false}}
 \ExecuteOptionsX{pbalance=false}
 %    \end{macrocode}
-% 
+%
 % \end{macro}
-% 
+%
 %
 % \begin{macro}{\if@ACM@natbib@override}
 % \changes{v1.12}{2016/05/30}{Added macro}
@@ -2386,7 +2386,7 @@
 %    \begin{macrocode}
 \newif\if@ACM@journal@bibstrip
 %    \end{macrocode}
-% 
+%
 % \end{macro}
 %
 % \begin{macro}{\if@ACM@sigchiamode}
@@ -2508,7 +2508,7 @@
 %    \begin{macrocode}
 \RequirePackage{booktabs}
 %    \end{macrocode}
-% 
+%
 %
 % We need |totpages| to calculate the number of pages and
 % |refcount| to use that number
@@ -2883,13 +2883,13 @@
 % Adding |hyperxmp|
 % \changes{v1.72}{2020/06/14}{Added hyperxmp}
 % \changes{v1.76}{2021/02/21}{Moved before hyperref, see
-% https://github.com/borisveytsman/acmart/issues/425} 
+% https://github.com/borisveytsman/acmart/issues/425}
 %    \begin{macrocode}
 \RequirePackage{hyperxmp}
 %    \end{macrocode}
-% 
 %
-% And now, |hyperref| 
+%
+% And now, |hyperref|
 % \changes{v1.28}{2017/01/07}{Got rid of warnings in pdf keywords}
 % \changes{v1.46}{2017/08/25}{Delayed hypersetup since journal options
 % may change screen mode}
@@ -3023,7 +3023,7 @@
           Legacy document. \\
           Not for publication in an ACM venue}}
     \fi
-  \fi  
+  \fi
 \fi
 %    \end{macrocode}
 %
@@ -3415,7 +3415,7 @@
   \let\@vspacer\@vspacer@orig}
 
 %    \end{macrocode}
-% 
+%
 %
 %\subsection{Floats}
 %\label{sec:floats}
@@ -3700,7 +3700,7 @@
 \newif\if@ACM@maketitle@typeset
 \@ACM@maketitle@typesetfalse
 %    \end{macrocode}
-% 
+%
 % \end{macro}
 %
 % \changes{v1.24}{2016/11/16}{Add IMWUT journal option}
@@ -4081,7 +4081,7 @@
   \ifx\acmConference@shortname\@empty
     \gdef\acmConference@shortname{#2}%
   \fi
-  \global\@ACM@journal@bibstripfalse  
+  \global\@ACM@journal@bibstripfalse
 }
 \if@ACM@journal\else
 \acmConference[Conference'17]{ACM Conference}{July 2017}{Washington,
@@ -4103,7 +4103,7 @@
 \acmBooktitle{Proceedings of \acmConference@name
        \ifx\acmConference@name\acmConference@shortname\else
        \ (\acmConference@shortname)\fi}
-\fi     
+\fi
 %    \end{macrocode}
 %
 % \end{macro}
@@ -4199,7 +4199,7 @@
 % entered.  The trick is based on the idea that |\csname...\endcsname|
 % is \cs{relax} unless defined.  Therefore we typeset authors by the
 % special macro |\csname typeset@author\the\num@authors\endcsname|,
-% which is defined by \cs{orcid} command.  
+% which is defined by \cs{orcid} command.
 %    \begin{macrocode}
 \renewcommand\author[2][]{%
   \IfSubStr{\detokenize{#2}}{,}{\ClassWarning{\@classname}{Do not put several
@@ -4339,7 +4339,7 @@
           \href{#1}{##1}}}{%
     \expandafter\gdef\csname
         typeset@author\the\num@authors\endcsname##1{%
-          \href{https://orcid.org/#1}{##1}}}}        
+          \href{https://orcid.org/#1}{##1}}}}
 %    \end{macrocode}
 %
 % \end{macro}
@@ -4662,7 +4662,7 @@
     for papers over two pages}%
   \fi\fi\fi}
 %    \end{macrocode}
-% 
+%
 % \end{macro}
 %
 %
@@ -5249,6 +5249,20 @@
 %
 % \end{macro}
 %
+% \begin{macro}{\anon}
+%   We provide \cs{anon} command, which blinds parts of the text
+%   if the package option |anonymous| is set
+%    \begin{macrocode}
+\newcommand{\anon}[2][ANONYMIZED]{%
+  \if@ACM@anonymous%
+    {\color{ACMOrange}#1}%
+  \else%
+    #2%
+  \fi}
+%    \end{macrocode}
+%
+% \end{macro}
+%
 %
 %\subsection{Maketitle hook}
 %\label{sec:hook}
@@ -5320,9 +5334,9 @@
 % \changes{v1.64}{2019/08/17}{Added a switch setting to show that
 % \cs{maketitle} is typeset}
 % \changes{v1.72}{2020/06/14}{Do not andify authors for pdf metadata
-% (Scott Pakin)} 
+% (Scott Pakin)}
 % \changes{v1.73}{2020/09/07}{Do not check again the presense of
-% address fields} 
+% address fields}
 % \changes{v1.75}{2020/11/15}{Added \cs{@beginmaketitlehook}}
 % \changes{v1.76}{2021/04/05}{Put \cs{par} inside group for keywords}
 %   The (in)famous \cs{maketitle}.  Note that in |sigchi-a| mode, authors
@@ -5502,7 +5516,7 @@
     \section*{#1}%
     \fi
   \let\@vspace\@vspace@acm
-  \let\@vspacer\@vspacer@acm    
+  \let\@vspacer\@vspacer@acm
 }
 %    \end{macrocode}
 %
@@ -5530,7 +5544,7 @@
   \@tempdima=\ht\mktitle@bx
   \advance\@tempdima by \dp\mktitle@bx
   \ifdim\@tempdima>0.9\textheight
-    \loop     
+    \loop
       \setbox\@tempboxa=\vsplit \mktitle@bx to 0.9\textheight
       \thispagestyle{firstpagestyle}%
       \noindent\unvbox\@tempboxa
@@ -5967,7 +5981,7 @@
 \newif\if@ACM@instpresent
 \@ACM@instpresenttrue
 %    \end{macrocode}
-% 
+%
 % \end{macro}
 %
 %
@@ -5978,7 +5992,7 @@
 \newif\if@ACM@citypresent
 \@ACM@citypresenttrue
 %    \end{macrocode}
-% 
+%
 % \end{macro}
 % \begin{macro}{\if@ACM@countrypresent}
 % \changes{v1.73}{2020/09/07}{Added macro}
@@ -5987,9 +6001,9 @@
 \newif\if@ACM@countrypresent
 \@ACM@countrypresenttrue
 %    \end{macrocode}
-% 
+%
 % \end{macro}
-% 
+%
 %
 % \begin{macro}{\@ACM@resetaffil}
 % \changes{v1.73}{2020/09/07}{Added macro}
@@ -6001,7 +6015,7 @@
   \global\@ACM@countrypresentfalse
 }
 %    \end{macrocode}
-% 
+%
 % \end{macro}
 %
 % \begin{macro}{\@ACM@checkaffil}
@@ -6022,7 +6036,7 @@
   \fi
 }
 %    \end{macrocode}
-% 
+%
 % \end{macro}
 %
 %
@@ -6355,7 +6369,7 @@
          \global\@undescribed@imagestrue
          \ClassWarning{\@classname}{A possible image without
            description}\fi
-    \medskip}%    
+    \medskip}%
   \fi}
 %    \end{macrocode}
 %
@@ -6739,7 +6753,7 @@
         \acmConference@shortname,
         \acmConference@date, \acmConference@venue\ACM@linecountR}%
     \fi
-  \fi  
+  \fi
   \if@ACM@sigchiamode
      \fancyheadoffset[L]{\dimexpr(\marginparsep+\marginparwidth)}%
   \fi
@@ -7356,7 +7370,7 @@
 %
 % We need balancing only if the user did not disable it, and we use a
 % two column format.  Note that |pbalance| uses a different
-% mechanism. 
+% mechanism.
 %    \begin{macrocode}
 \AtEndPreamble{%
   \if@ACM@pbalance
@@ -7376,7 +7390,7 @@
        \or % sigchi
           \RequirePackage{pbalance}%
        \or % sigchi-a
-    \fi  
+    \fi
   \fi
   \if@ACM@balance
     \ifcase\ACM@format@nr
@@ -7397,7 +7411,7 @@
        \or % sigchi
           \RequirePackage{balance}%
        \or % sigchi-a
-          \global\@ACM@balancefalse  
+          \global\@ACM@balancefalse
     \fi
   \fi
 }
@@ -7407,7 +7421,7 @@
   \balance
   \fi\fi}
 %    \end{macrocode}
-% 
+%
 %
 %\subsection{Acknowledgments}
 %\label{sec:acks}
@@ -7478,7 +7492,7 @@
 \fi}
 %    \end{macrocode}
 %
-% 
+%
 %
 %\subsection{Additional bibliography commands}
 %\label{sec:bibliography}
@@ -7487,7 +7501,7 @@
 % \changes{v1.21}{2016/09/04}{Added macro}
 % The command \cs{showeprint} has two arguments: the (optional)
 % prefix and the eprint number.  Right now the only prefix we understand is
-% the (lowercase) word `arxiv'. 
+% the (lowercase) word `arxiv'.
 %    \begin{macrocode}
 \newcommand\showeprint[2][arxiv]{%
   \def\@tempa{#1}%
@@ -7525,7 +7539,7 @@
   \hyphenpenalty\@M
   \footnotesize}
 %    \end{macrocode}
-% 
+%
 % \end{macro}
 %
 %\subsection{End of Class}
@@ -7542,14 +7556,14 @@
 \let\@vspacer@orig=\@vspacer
 \apptocmd{\@vspace}{\ClassWarning{\@classname}{\string\vspace\space should
     only be used to provide space above/below surrounding
-    objects}}{}{} 
+    objects}}{}{}
 \apptocmd{\@vspacer}{\ClassWarning{\@classname}{\string\vspace\space should
     only be used to provide space above/below surrounding
     objects}}{}{}
 \let\@vspace@acm=\@vspace
 \let\@vspacer@acm=\@vspacer
 %    \end{macrocode}
-% 
+%
 % \end{macro}
 %
 %
@@ -7564,7 +7578,7 @@
     \string\baselinestretch\space detected.  Please do not do this for
     ACM submissions!}\fi}
 %    \end{macrocode}
-% 
+%
 % \end{macro}
 %
 % \changes{v1.30}{2017/02/10}{Added \cs{frenchspacing}}


### PR DESCRIPTION
As suggested in #455 a new command `\anon` was added and briefly documented.

My editor removed trailing spaces from some lines. I believe, it's not a problem and only makes the document cleaner.