### PR TITLE
Fix German translations and capitalization of title

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -2821,9 +2821,9 @@
   }%
   \addto\captionsgerman{%
       \if@ACM@journal
-        \renewcommand\keywordsname{Zusätzliche Schlüsselwörter und Phrasen}%
+        \renewcommand\keywordsname{Zusätzliche Schlagwörter und Phrasen}%
       \else
-        \renewcommand\keywordsname{Schlüsselwörter}%
+        \renewcommand\keywordsname{Schlagwörter}%
       \fi 
       \renewcommand\acksname{Danksagungen}%
   }%

--- a/samples/samples.dtx
+++ b/samples/samples.dtx
@@ -281,8 +281,8 @@
 %<sigconf-i13n>\translatedkeywords{french}{ensembles de données,
 %<sigconf-i13n> réseaux de neurones,
 %<sigconf-i13n>  détection du regard, marquage de texte}
-%<sigconf-i13n>  \translatedkeywords{german}{Datensätze,
-%<sigconf-i13n> neuronale Netze, Blickerkennung, Text-Tagging}
+%<sigconf-i13n>  \translatedkeywords{german}{Datensammlungen,
+%<sigconf-i13n> neuronale Netze, Blickerkennung, Textklassifizierung}
 %<sigconf-i13n> \translatedkeywords{spanish}{conjuntos de datos,
 %<sigconf-i13n> redes neuronales, detección de mirada, etiquetado de texto} 
 

--- a/samples/samples.dtx
+++ b/samples/samples.dtx
@@ -104,7 +104,7 @@
 %%
 %% The "title" command has an optional parameter,
 %% allowing the author to define a "short title" to be used in page headers.
-\title{The Name of the Title is Hope}
+\title{The Name of the Title Is Hope}
 %<sigconf-i13n>\translatedtitle{french}{Le nom du titre est l'espoir}
 %<sigconf-i13n>\translatedtitle{german}{Der Name des Titels ist Hoffnung}
 %<sigconf-i13n>\translatedtitle{spanish}{El nombre del título es esperanza}

--- a/samples/samples.dtx
+++ b/samples/samples.dtx
@@ -220,13 +220,12 @@
 \end{translatedabstract}
 
 \begin{translatedabstract}{german}
-  Ein übersichtliches und gut dokumentiertes \LaTeX\-Dokument wird als
-  Artikel, der für die Veröffentlichung durch ACM in einem Tagungsband
-  formatiert wurde oder Zeitschriftenveröffentlichung. Basierend auf
-  der Dokumentenklasse ``acmart'', this Artikel präsentiert und
-  erklärt auch viele der gängigen Variationen so viele der
-  Formatierungselemente, die ein Autor in der verwenden darf
-  Vorbereitung der Dokumentation ihrer Arbeit.
+  Es wird ein übersichtliches und gut dokumentiertes \LaTeX\-Dokument präsentiert,
+  welches für die Veröffentlichung durch ACM in einem Tagungsband oder
+  als Zeitschriftenpublikation formatiert wurde.
+  Basierend auf der Dokumentenklasse “acmart” präsentiert und erklärt dieser Artikel
+  viele der Formatierungselemente sowie auch viele der gängigen Variationen,
+  die ein Autor bei der Beschreibung seiner Arbeit verwenden darf.
 \end{translatedabstract}
 
 \begin{translatedabstract}{spanish}


### PR DESCRIPTION
The first commit fixes the capitalization of the English title.
(According to Chicago Manual of Style, verbs are capitalized.)

The second commit fixes the German abstract language-wise.
Before it read like translated by Google Translate.
I also changed "Schlüsselwörter" to the more librarian notion of "Schlagwörter".

The third commit fixes the keywords.
("Datensätze" would be used rather for records or entries,
wheras I would translate data sets to "Datensammlungen".
"Tagging" is not a German word, so I changed to "Klassifizierung".)

While this its all not extremely important, I thought it would be good if the sample looks good.