### PR TITLE
Separate keywords by semi-colons

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -925,10 +925,10 @@
 % The command
 % \cs{keywords}\marg{keyword, keyword,\ldots} sets keywords for the
 % article.  They must be
-% separated by commas, for example,
+% separated by semi-colons, for example,
 % \begin{verbatim}
-% \keywords{wireless sensor networks, media access control,
-% multi-channel, radio interference, time synchronization}
+% \keywords{wireless sensor networks; media access control;
+% multi-channel; radio interference; time synchronization}
 % \end{verbatim}
 %
 % \DescribeEnv{CCSXML}%

--- a/samples/samples.dtx
+++ b/samples/samples.dtx
@@ -317,15 +317,16 @@
 
 %%
 %% Keywords. The author(s) should pick words that accurately describe
-%% the work being presented. Separate the keywords with commas.
-\keywords{datasets, neural networks, gaze detection, text tagging}
-%<sigconf-i13n>\translatedkeywords{french}{ensembles de données,
-%<sigconf-i13n> réseaux de neurones,
-%<sigconf-i13n>  détection du regard, marquage de texte}
-%<sigconf-i13n>  \translatedkeywords{german}{Datensätze,
-%<sigconf-i13n> neuronale Netze, Blickerkennung, Text-Tagging}
-%<sigconf-i13n> \translatedkeywords{spanish}{conjuntos de datos,
-%<sigconf-i13n> redes neuronales, detección de mirada, etiquetado de texto} 
+%% the work being presented. Separate the keywords with semi-colons
+%% because there is a growing amount of technical terms with commas.
+\keywords{datasets; neural networks; gaze detection; text tagging}
+%<sigconf-i13n>\translatedkeywords{french}{ensembles de données;
+%<sigconf-i13n> réseaux de neurones; détection du regard;
+%<sigconf-i13n> marquage de texte}
+%<sigconf-i13n> \translatedkeywords{german}{Datensätze;
+%<sigconf-i13n> neuronale Netze; Blickerkennung; Text-Tagging}
+%<sigconf-i13n> \translatedkeywords{spanish}{conjuntos de datos;
+%<sigconf-i13n> redes neuronales; detección de mirada; etiquetado de texto}
 %</manuscript|acmsmall|acmsmall-submission|acmsmall-biblatex|acmlarge|acmtog|sigconf|sigconf-biblatex|authordraft|sigplan|sigchi|sigchi-a|acmsmall-conf|sigconf-i13n>
 %<*sigconf|authordraft|sigplan|acmsmall-conf|sigconf-i13n>
 %% A "teaser" image appears between the author and affiliation
@@ -335,7 +336,7 @@
   \includegraphics[width=\textwidth]{sampleteaser}
   \caption{Seattle Mariners at Spring Training, 2010.}
   \Description{Enjoying the baseball game from the third-base
-  seats. Ichiro Suzuki preparing to bat.} 
+  seats. Ichiro Suzuki preparing to bat.}
   \label{fig:teaser}
 \end{teaserfigure}
 %</sigconf|authordraft|sigplan|acmsmall-conf|sigconf-i13n>


### PR DESCRIPTION
ACM frequently relies on Sheridan Communications for the processing of final versions. Their instructions require authors to separate the keywords by semi-colons.

> Cut and paste the author keywords into the Keywords field, separated with semi-colons.
Separating your keywords; with semi-colons; is mandatory because there is a growing amount of technical terms with commas. Keywords separated with commas will be included as one elongated term. 

This requirement is a mismatch to the information provided in the acmart template. Thus, this pull request changes the default separator from comma to semi-colon.