### PR TITLE
Document option necessary to use biblatex.

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1775,7 +1775,10 @@
 % when using Bib\LaTeX\ instead of Bib\TeX, that we summarize briefly
 % here (please refer to the official Bib\LaTeX\ documentation for more details).
 %
-% In the preamble of your document you need to load the Bib\LaTeX\ package
+% First of all, you need to pass the \verb|natbib=false| option to the document class,
+% and remove the \verb|\citestyle{acmauthoryear}| command from the sources (if present).
+%
+% Then, in the preamble of your document you need to load the Bib\LaTeX\ package
 % and select the approriate bibliography style, as follows
 % \begin{verbatim}
 % \RequirePackage[


### PR DESCRIPTION
Add explicit documentation about the need to pass natbib=false in the documentclass, and to remove any occurrence of \citestyle{authoryear} when using biblatex.

Fixes issue mentioned in PR #466