### PR TITLE
[samples] fix a typo: emai -> email inside acmConference

### DIFF
--- a/samples/samples.dtx
+++ b/samples/samples.dtx
@@ -63,7 +63,7 @@
 %<*manuscript|sigconf|authordraft|sigplan|sigchi|sigchi-a|acmsmall-conf|sigconf-i13n>
 %% These commands are for a PROCEEDINGS abstract or paper.
 \acmConference[Conference acronym 'XX]{Make sure to enter the correct
-  conference title from your rights confirmation emai}{June 03--05,
+  conference title from your rights confirmation email}{June 03--05,
   2018}{Woodstock, NY}
 %%
 %%  Uncomment \acmBooktitle if the title of the proceedings is different


### PR DESCRIPTION
Trivial: in `\acmConference` the word `email` is missing an an `l'.
Also apparently an EOL was missing at the EOF :)