### PR TITLE
doc: change \acmBadgeR to \acmBadge

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -931,7 +931,7 @@
 % the output.  For example, if the badge image is |ae-logo.pdf|, the
 % command is
 % \begin{verbatim}
-% \acmBadgeR[http://ctuning.org/ae/ppopp2016.html]{ae-logo}
+% \acmBadge[http://ctuning.org/ae/ppopp2016.html]{ae-logo}
 % \end{verbatim}
 % The command can be repeated, if a paper has several badges.  
 %


### PR DESCRIPTION
I find it confusing that the documentation of \acmBadge has an example that uses \acmBadgeR, not \acmBadge. After looking at the history, I found the commit b17e331a, which replaces \acmBadgeR with \acmBadge (though internally it is just a syntactic sugar of \acmBadgeR). However, the example in the documentation was not similarly updated to reflect this. This PR fixes the issue.