### PR TITLE
fixes #506 - hide authornotemark when anonymous is set

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -5124,10 +5124,12 @@
 % Adding a footnote mark to the authors
 %    \begin{macrocode}
 \newcommand\authornotemark[1][\relax]{%
-  \ifx#1\relax\relax\relax
-  \g@addto@macro\addresses{\@authornotemark}%
-  \else
-  \g@addto@macro\addresses{\@@authornotemark{#1}}%
+  \if@ACM@anonymous\else
+    \ifx#1\relax\relax\relax
+      \g@addto@macro\addresses{\@authornotemark}%
+    \else
+      \g@addto@macro\addresses{\@@authornotemark{#1}}%
+    \fi
   \fi}
 %    \end{macrocode}
 %


### PR DESCRIPTION
This fixes issue #506, so that if someone uses `\authornotemark` while `anonymous` is enabled on the class the author string shows as:

> Anonymous Author(s)

instead of as:

> Anonymous Author(s)*