### PR TITLE
Tiny wih->with typo fixed in acmart.dtx

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -1302,7 +1302,7 @@
 % languages are \emph{secondary,} and used for translated titles,
 % keywords, abstracts.  Thus the paper above is written in English,
 % and has a secondary abstract and a secondary title in French.  On
-% the other hand, a paper in French wih secondary titles and abstracts
+% the other hand, a paper in French with secondary titles and abstracts
 % in English and German should use, for example
 % \begin{verbatim}
 % \documentclass[sigconf,


### PR DESCRIPTION
There's a really small typo in the documentation for multilanguage usage. It's fixed here.