### PR TITLE
Patching lstinputlisting to prevent spurious space warnings

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -4029,6 +4029,10 @@
   \let\@vspacer\@vspacer@orig}
 \AtBeginEnvironment{listing*}{\let\@vspace\@vspace@orig
   \let\@vspacer\@vspacer@orig}
+\AtBeginEnvironment{lstinputlisting}{\let\@vspace\@vspace@orig
+  \let\@vspacer\@vspacer@orig}
+\AtBeginEnvironment{lstinputlisting*}{\let\@vspace\@vspace@orig
+  \let\@vspacer\@vspacer@orig}
 
 %    \end{macrocode}
 %


### PR DESCRIPTION
Same approach as lstlisting to prevent spurious space warnings.