### PR TITLE
bst: Remove dangling comma before number of pages in `@misc` items

### DIFF
--- a/ACM-Reference-Format.bst
+++ b/ACM-Reference-Format.bst
@@ -2419,7 +2419,6 @@ FUNCTION { misc }
     { }
     { "\bibinfo{howpublished}{" howpublished "}" * * output }
   if$
-  "" output.nonnull.dot.space
   calc.format.page.count output
   fin.block
   output.issue.doi.coden.isxn.lccn.url.eprint.note


### PR DESCRIPTION
I'm not sure whether this is the right fix, but it works for me. The bug was that a bibentry like this:

```bib
@misc{zhao2023survey,
	title	= {A Survey of Large Language Models},
	author	= {Wayne Xin Zhao and others},
 	year	= {2023},
	eprint	= {2303.18223},
	archivePrefix	= {arXiv},
	primaryClass	= {cs.CL},
	numpages	= {124}
}
```

was printed like this before:

    Wayne Xin Zhao et al. 2023. A Survey of Large Language Models. , 124 pages. arXiv:2303.18223 [cs.CL]