### PR TITLE
Add requirement (acmart requires doclicense)

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -221,6 +221,7 @@
 % \item \textsl{caption}, \url{https://ctan.org/pkg/caption},
 % \item \textsl{cmap}, \url{https://ctan.org/pkg/cmap},
 % \item \textsl{comment}, \url{https://ctan.org/pkg/comment},
+% \item \textsl{doclicense}, \url{https://ctan.org/pkg/doclicense},
 % \item \textsl{draftwatermark}, \url{https://ctan.org/pkg/draftwatermark},
 % \item \textsl{environ}, \url{https://ctan.org/pkg/environ},
 % \item \textsl{etoolbox}, \url{https://ctan.org/pkg/etoolbox},


### PR DESCRIPTION
The options that use icons from Creative Commons require files from the package `doclicense`.
This PR adds the requirement to the installation instructions.