### PR TITLE
Fix a typo (\relax -> \or) introduced when adding new journals

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -4606,12 +4606,12 @@
   \def\@journalNameShort{ACM J. Comput. Sustain. Soc.}%
   \def\@permissionCodeOne{2834-5533}%
   \def\@permissionCodeTwo{2834-5533}%
-\relax % ACMJCDS
+\or % ACMJCDS
   \def\@journalName{ACM Journal of Data Science}%
   \def\@journalNameShort{ACM J. Data Sci.}%
   \def\@permissionCodeOne{0000-0000}%
   \def\@permissionCodeTwo{0000-0000}%
-\relax % AILET
+\or % AILET
   \def\@journalName{ACM AI Letters}%
   \def\@journalNameShort{ACM AI Lett.}%
   \def\@permissionCodeOne{3068-8590}%


### PR DESCRIPTION
Fixes #565 
Fixes a typo introduced in 57e6ffe6f3ab522b2a9ba2da2bf411aa38676568

The following LaTeX document
```
\documentclass[acmsmall]{acmart}

\acmJournal{PACMPL}

\begin{document}
\title{Test Title}
\maketitle
\end{document}
```
produces a PDF with for the journal `Proc. ACM Meas. Anal. Comput. Syst.`, see ACM Reference Format,
although `\acmJournal{PACMPL}` was specified.

Here the produced PDF: [main.pdf](https://github.com/user-attachments/files/22009598/main.pdf)