### PR TITLE
Do not make the page count a hyperlink

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -7728,14 +7728,14 @@
     \if@ACM@journal@bibstrip
        \textit{\@journalNameShort}
        \@acmVolume, \@acmNumber \@article@string (\@acmPubDate),
-       \ref{TotPages}~\@pages@word.
+       \ref*{TotPages}~\@pages@word.
     \else
        In \textit{\@acmBooktitle}%
        \ifx\@acmEditors\@empty\textit{.}\else
          \andify\@acmEditors\textit{, }\@acmEditors~\@editorsAbbrev.%
        \fi\
        ACM, New York, NY, USA%
-         \@article@string\unskip, \ref{TotPages}~\@pages@word.
+         \@article@string\unskip, \ref*{TotPages}~\@pages@word.
     \fi
   \fi
   \ifx\@acmDOI\@empty\else\@formatdoi{\@acmDOI}\fi


### PR DESCRIPTION
Hi, the page count in the "ACM Reference Format" on the first page is a hyperlink to the last page, is that intentional? It looks rather odd on in the screen version, since hyperlinks have a different colour.

This PR disables that hyperlink.