### PR TITLE
Fix the long name for TOPML

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -2218,7 +2218,7 @@
 %     TOMS & ACM Transactions on Mathematical Software\\
 %     TOPC & ACM Transactions on Parallel Computing\\
 %     TOPLAS & ACM Transactions on Programming Languages and Systems\\
-%     TOPML & ransactions on Probabilistic Machine Learning\\
+%     TOPML & ACM Transactions on Probabilistic Machine Learning\\
 %     TOPS & ACM Transactions on Privacy and Security\\
 %     TORS & ACM Transactions on Recommender Systems\\
 %     TOS & ACM Transactions on Storage\\


### PR DESCRIPTION
This pull request is about the correction of an earlier commit that contained a naming mistake (maybe through copy&paste or editor key combination).

See the commit message for details.