### PR TITLE
Add missing commands for showing ISBN numbers for books.

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -8978,6 +8978,20 @@
 %
 % \end{macro}
 %
+% \begin{macro}{\showISBNx}
+% \begin{macro}{\showISBNxiii}
+% \changes{v2.19}{2026/08/04}{Added macros}
+% The bibliography style calls \cs{showISBNx} for a 10-digit
+% \textsc{isbn} and \cs{showISBNxiii} for a 13-digit one.
+%    \begin{macrocode}
+\newcommand\showISBNx[1]{ISBN~#1.}
+\newcommand\showISBNxiii[1]{ISBN-13~#1.}
+%    \end{macrocode}
+%
+% \end{macro}
+%
+% \end{macro}
+%
 %
 %\subsection{Index}
 %\label{sec:index}


### PR DESCRIPTION
The bibliography style calls \cs{showISBNx} for a 10-digit \textsc{isbn} and \cs{showISBNxiii} for a 13-digit one. The \texttt{.bbl} file turns both into no-ops unless the class defines them first, so without the definitions below no \textsc{isbn} is ever typeset. Each macro supplies its own final punctuation, as the \texttt{.bbl} preamble requires.
The two labels differ because a single entry carrying both \texttt{isbn} and \texttt{isbn-13} fields produces one call of each.