### PR TITLE
Fix alphabetical labels for same-author n.d. entries

### DIFF
--- a/ACM-Reference-Format.bst
+++ b/ACM-Reference-Format.bst
@@ -2052,7 +2052,7 @@ FUNCTION { calc.basic.label }
   duplicate$
   year empty.or.unknown
     { date empty.or.unknown
-        { "{[n.\,d.]}" }
+	{ "0000" }
 	{ date field.or.null purify$ #1 #4 substring$}
       if$
     }
@@ -2104,7 +2104,7 @@ FUNCTION { calc.label }
   %
   year empty.or.unknown
     { date empty.or.unknown
-        { "{[n.\,d.]}" }
+	{ "0000" }
 	{ date field.or.null purify$ #1 #4 substring$}
       if$
     }
@@ -2167,6 +2167,7 @@ FUNCTION { output.issue.doi.coden.isxn.lccn.url.eprint }
 
 FUNCTION { output.issue.doi.coden.isxn.lccn.url.eprint.note }
 { % enter with stack empty, return with empty string on stack
+  output.issue.doi.coden.isxn.lccn.url.eprint
   note empty.or.unknown
     { }
     {
@@ -2174,12 +2175,12 @@ FUNCTION { output.issue.doi.coden.isxn.lccn.url.eprint.note }
       output.note
     }
   if$
-  output.issue.doi.coden.isxn.lccn.url.eprint
   ""
 }
 
 FUNCTION { output.issue.doi.coden.isxn.lccn.url.eprint.note.check }
 { % enter with stack empty, return with empty string on stack
+  output.issue.doi.coden.isxn.lccn.url.eprint
   note empty.or.unknown
     { }
     {
@@ -2187,7 +2188,6 @@ FUNCTION { output.issue.doi.coden.isxn.lccn.url.eprint.note.check }
       output.note.check
     }
   if$
-  output.issue.doi.coden.isxn.lccn.url.eprint
   ""
 }
 
@@ -3087,14 +3087,30 @@ FUNCTION { forward.pass }
   % if two entries are the same (see presort)
 
   last.label
-  calc.basic.label year field.or.null purify$ #-1 #4 substring$ * % add year
+  calc.basic.label
+  year empty.or.unknown
+    { date empty.or.unknown
+        { "0000" * }
+	{ date field.or.null purify$ #1 #4 substring$ * }
+      if$
+    }
+    { year field.or.null purify$ #-1 #4 substring$ * }
+  if$
   #1 entry.max$ substring$ =     % are they equal?
      { last.extra.num #1 + 'last.extra.num :=
        last.extra.num int.to.chr$ 'extra.label :=
      }
      { "a" chr.to.int$ 'last.extra.num :=
        "" 'extra.label :=
-       calc.basic.label year field.or.null purify$ #-1 #4 substring$ * % add year
+       calc.basic.label
+       year empty.or.unknown
+         { date empty.or.unknown
+             { "0000" * }
+	     { date field.or.null purify$ #1 #4 substring$ * }
+           if$
+         }
+         { year field.or.null purify$ #-1 #4 substring$ * }
+       if$
        #1 entry.max$ substring$ 'last.label := % assign to last.label
      }
   if$
@@ -3206,6 +3222,10 @@ FUNCTION { begin.bib }
   "\providecommand\bibinfo[2]{#2}" writeln
   "\providecommand\natexlab[1]{#1}" writeln
   "\providecommand\showeprint[2][]{arXiv:#2}" writeln
+  "\makeatletter" writeln
+  "\@ifundefined{NAT@parse@date}{}{\let\NAT@parse@date@orig\NAT@parse@date}" writeln
+  "\@ifundefined{NAT@parse@date}{}{\def\NAT@parse@date#1#2#3#4#5#6@@{\NAT@parse@date@orig#1#2#3#4#5#6@@\def\NAT@tempyear{0000}\def\NAT@tempexlab{{?}}\ifx\NAT@year\NAT@tempyear\ifx\NAT@exlab\NAT@tempexlab\def\NAT@date{[n.\,d.]}\else\edef\NAT@date{[n.\,d.]\NAT@exlab}\fi\fi}}" writeln
+  "\makeatother" writeln
 }
 
 EXECUTE {begin.bib}


### PR DESCRIPTION
This pull request updates the `ACM-Reference-Format.bst` BibTeX style file to fix an error occurring with `natbib` when multiple references by the same authors have no publication year. In particular, using multiple `n.d.` entries for the same authors caused `natbib` to generate alphabetical year identifiers (e.g., `[n.d.]a`, `[n.d.]b`), which resulted in multiple errors.

To avoid this issue, the style file now uses `"0000"` internally as a placeholder for missing publication years, while converting it back to `[n.\,d.]` only in the final bibliography output. Additionally, some function ordering has been adjusted for clarity and correctness.

Key changes include:

**Fix for `natbib` errors with multiple `n.d.` references:**

* Changed the internal representation of missing publication years from `{[n.\,d.]}` to `"0000"` to prevent `natbib` from treating `[n.d.]` as a year and appending alphabetical identifiers such as `[n.d.]a`.
* Updated label generation and comparison logic to consistently use `"0000"` for missing years.

**LaTeX macro enhancements for output formatting:**

* Added LaTeX macros in `begin.bib` to detect `"0000"` years and convert them back to `[n.\,d.]` in the final bibliography output, preserving the intended formatting for entries with unknown publication years.

**Function call order corrections:**

* Moved calls to `output.issue.doi.coden.isxn.lccn.url.eprint` earlier in the `output.issue.doi.coden.isxn.lccn.url.eprint.note` and `output.issue.doi.coden.isxn.lccn.url.eprint.note.check` functions to ensure the correct output order.

Overall, the changes preserve the existing `[n.\,d.]` bibliography formatting while preventing `natbib` errors when multiple works by the same authors have no publication year.
