### PR TITLE
Restore the authors' contact information footnote in acmsmall conference mode

### DIFF
--- a/acmart.dtx
+++ b/acmart.dtx
@@ -300,7 +300,9 @@
 % the headers, and no folios, since the page numbers of such a paper
 % are assigned by the proceedings rather than by the article.  If you
 % do want the folios, say |\settopmatter{printfolios=true}| after
-% \cs{acmConference}.
+% \cs{acmConference}.  Both formats keep the journal authors block and
+% the footnote with the authors' contact information, since these
+% formats do not print the contact information in the authors block.
 %
 % \begin{table}
 %   \centering
@@ -2941,6 +2943,22 @@
 %
 % \end{macro}
 %
+% \begin{macro}{\if@ACM@addressesinfootnote}
+% \changes{v2.21}{2026/08/28}{Introduced macro}
+% The formats using the journal-style authors block do not print the
+% authors' contact information there, so they print it in a footnote on
+% the first page instead.  Whether they do is a property of the format
+% and of \cs{acmJournal}, and unlike
+% \cs{if@ACM@journal@bibstrip@or@tog} it must not be changed by
+% \cs{acmConference}: a journal format used for conference proceedings
+% still has the journal-style authors block, so it still needs the
+% footnote.
+%    \begin{macrocode}
+\newif\if@ACM@addressesinfootnote
+%    \end{macrocode}
+%
+% \end{macro}
+%
 % 
 % \begin{macro}{\if@ACM@sigchiamode}
 %   The formatting of SIGCHI extended abstracts is quite unusual.  We have a
@@ -3038,6 +3056,7 @@
 \if@ACM@journal
   \@ACM@journal@bibstriptrue
   \@ACM@journal@bibstrip@or@togtrue
+  \@ACM@addressesinfootnotetrue
 \else
  \@ACM@journal@bibstripfalse
 \fi
@@ -5054,11 +5073,13 @@
 %    \end{macrocode}
 % \begin{macro}{\acmJournal}
 % \changes{v1.59}{2019/04/20}{Setting \cs{@ACM@journal@bibstrip}}
+% \changes{v2.21}{2026/08/28}{Setting \cs{@ACM@addressesinfootnote}}
 % And the syntactic sugar around it
 %    \begin{macrocode}
 \def\acmJournal#1{\setkeys{ACM}{acmJournal=#1}%
   \global\@ACM@journal@bibstriptrue
-  \global\@ACM@journal@bibstrip@or@togtrue}
+  \global\@ACM@journal@bibstrip@or@togtrue
+  \global\@ACM@addressesinfootnotetrue}
 %    \end{macrocode}
 %
 % \end{macro}
@@ -6625,6 +6646,9 @@
 % TOG}
 % \changes{v2.11}{2024/12/07}{Deleted conference date from bibstrip}
 % \changes{v2.21}{2026/08/30}{Start footnotes from 2}
+% \changes{v2.21}{2026/08/28}{The footnote with the authors' contact
+%   information no longer depends on the style of the bibstrip and the
+%   page headers}
 %   The (in)famous \cs{maketitle}.  Note that in |sigchi-a| mode, authors
 %   are \emph{not} in the title box.
 %
@@ -6669,7 +6693,7 @@
   \if@ACM@acmcp\else
     \ifx\@empty\@authorsaddresses\else
        \if@ACM@anonymous\else
-         \if@ACM@journal@bibstrip@or@tog
+         \if@ACM@addressesinfootnote
            \footnotetextauthorsaddresses{%
              \def\par{\let\par\@par}\parindent\z@\@setauthorsaddresses}%
          \fi


### PR DESCRIPTION
The journal formats do not print the authors' contact information in the authors block, so they print it in the "Authors' Contact Information" footnote on the first page instead.  That footnote was guarded by \if@ACM@journal@bibstrip@or@tog, a flag that describes the style of the bibstrip and, since v2.20, also the style of the page headers and footers.

In v2.20 \acmConference clears this flag for acmsmall, so that conference proceedings in that format get the headers and footers of the proceedings formats.  As a side effect the footnote is now suppressed.  The authors block is chosen by format number and is unchanged, so it is still the compact journal-style line without e-mail addresses, and the contact information disappears from the paper entirely: sample-acmsmall-conf.pdf built with v2.19 has the footnote, built with v2.20 it does not.  acmtog used for proceedings is unaffected and still prints it.

Guard the footnote by a new flag \if@ACM@addressesinfootnote instead, which records whether the authors block carries the contact information. It is set for the journal formats and by \acmJournal, and \acmConference does not clear it.  This restores the footnote for acmsmall proceedings while keeping the v2.20 headers, footers and folios, and leaves every other combination unchanged -- in particular a proceedings format used for a journal, such as sigplan with \acmJournal for PACMPL, keeps the footnote it prints today.

(agentic development)